### PR TITLE
Passes props to performAction instead of `this`

### DIFF
--- a/src/Thermite/Internal.purs
+++ b/src/Thermite/Internal.purs
@@ -78,7 +78,7 @@ foreign import createClassImpl """
             return spec.initialState;
           },
           performAction: function(action) {
-            runAction(this)(spec.performAction(this)(action))();
+            runAction(this)(spec.performAction(this.props)(action))();
           },
           render: function() {
             return spec.render(this)(this.state)(this.props);


### PR DESCRIPTION
Fixes an issue where `this.props` wasn't being correctly passed to `spec.performAction`, which is what the types are indicating was happening 