### PR TITLE
Export React "key" attribute

### DIFF
--- a/src/Thermite/Html/Attributes.purs
+++ b/src/Thermite/Html/Attributes.purs
@@ -144,6 +144,9 @@ icon = unsafeAttribute "icon"
 _id :: forall action. String -> Prop action
 _id = unsafeAttribute "id"
 
+key :: forall action. String -> Prop action
+key = unsafeAttribute "key"
+
 label :: forall action. String -> Prop action
 label = unsafeAttribute "label"
 


### PR DESCRIPTION
Necessary when creating dynamic children:
https://facebook.github.io/react/docs/multiple-components.html#dynamic-children