### PR TITLE
Change disabled attribute type signature

### DIFF
--- a/src/Thermite/Html/Attributes.purs
+++ b/src/Thermite/Html/Attributes.purs
@@ -87,7 +87,7 @@ defer = unsafeAttribute "defer"
 dir :: forall action. String -> Prop action
 dir = unsafeAttribute "dir"
 
-disabled :: forall action. String -> Prop action
+disabled :: forall action. Boolean -> Prop action
 disabled = unsafeAttribute "disabled"
 
 download :: forall action. String -> Prop action


### PR DESCRIPTION
Under the covers, React will do the right thing w/ the disabled attribute based on its truthy-ness or falsey-ness. Strings are always truthy so setting a string here will always disable the widget.