### PR TITLE
change the way React.createElement is called

### DIFF
--- a/src/Thermite/Html.purs
+++ b/src/Thermite/Html.purs
@@ -1,8 +1,9 @@
 -- | This module defines functions for creating simple HTML documents.
 
-module Thermite.Html 
+module Thermite.Html
   ( text
-  , createElement  
+  , array
+  , createElement
   , component
   ) where
 
@@ -12,6 +13,9 @@ import Thermite.Internal
 -- | Create a text node.
 text :: forall eff. String -> Html eff
 text = textImpl
+
+array :: forall eff. [Html eff] -> Html eff
+array = passArrayImpl
 
 -- | Create a HTML element from a tag name, a set of attributes and a collection of child nodes.
 createElement :: forall eff. String -> Attr -> [Html eff] -> Html eff

--- a/src/Thermite/Internal.purs
+++ b/src/Thermite/Internal.purs
@@ -32,6 +32,12 @@ foreign import textImpl """
   }
   """ :: forall eff. String -> Html eff
 
+foreign import passArrayImpl """
+  function passArrayImpl(a) {
+    return [a];
+  }
+  """ :: forall eff. [Html eff] -> Html eff
+
 foreign import createElementImpl """
   function createElementImpl(element) {
     return function(props) {
@@ -39,7 +45,7 @@ foreign import createElementImpl """
         if ("dangerouslySetInnerHTML" in props) {
           return React.createElement(element, props);
         } else {
-          return React.createElement(element, props, children);
+          return React.createElement.apply(this, [element, props].concat(children));
         }
       };
     };


### PR DESCRIPTION
this is a change for paf31/purescript-thermite#27

when you return an array of JSX elements, it passes
an array as children in createElement, so this works:

    <div>
      { this.props.map(function(el) {
        return <span>{el}</span>;
      }}
    </div>

but when you structure your tree like this:

    <div>
      <span>one</span>
      <span>two</span>
    </div>

it calls createElement(..., <span>one</span>, <span>two</span>).

this is important because elements passed in the 2nd way
don't require unique keys and reacts fills them in automatically.

when passing elements the first way you always have to give unique
keys yourself