### PR TITLE
add unsafe style attribute

### DIFF
--- a/src/Thermite/Html/Attributes/Unsafe.purs
+++ b/src/Thermite/Html/Attributes/Unsafe.purs
@@ -7,3 +7,12 @@ import Thermite.Internal
 
 innerHTML :: String -> Attr
 innerHTML s = unsafeAttribute "dangerouslySetInnerHTML" { "__html": s }
+
+style :: forall a. a -> Attr
+style = unsafeAttribute "style" <<< styleUnsafe
+
+foreign import styleUnsafe """
+    function styleUnsafe(a) {
+      return a;
+    }
+  """ :: forall a. a -> Attr


### PR DESCRIPTION
Can be used like this:

```
--- imports
import qualified Thermite.Html.Attributes.Unsafe as A

render :: T.Render _ Unit Props Unit
render _ _ props _ = T.div (A.style style) [ T.text "test"]
  where
  style = { color: "red" }

```