### PR TITLE
Fix example link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 `purescript-thermite` is a simple PureScript wrapper for ReactJS inspired by `react-blaze`. It does not (and does not aim to) provide all of the functionality of ReactJS, but instead to provide a clean API to the most commonly-used parts of its API.
 
 - [Module Documentation](docs/)
-- [Example](example/Main.purs)
+- [Example](test/Main.purs)
 - [Task List Example](https://github.com/paf31/purescript-thermite-todomvc)
 
 ## Building


### PR DESCRIPTION
This changed during the 0.7 upgrade.