### PR TITLE
Fix some warnings

### DIFF
--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -31,9 +31,6 @@ module Thermite
 
 import Prelude
 
-import DOM
-import DOM.Node.Types
-
 import Data.Lens
 import Data.List
 import Data.Tuple

--- a/test/Components/Task.purs
+++ b/test/Components/Task.purs
@@ -2,18 +2,8 @@ module Components.Task where
 
 import Prelude
 
-import Data.Lens
-import Data.List
-import Data.Tuple
-import Data.Either
-import Data.Foldable (fold)
-
-import Control.Monad.Eff
-import Control.Monad.Eff.Unsafe
-
 import qualified Thermite as T
 
-import qualified React as R
 import qualified React.DOM as R
 import qualified React.DOM.Props as RP
 

--- a/test/Components/TaskList.purs
+++ b/test/Components/TaskList.purs
@@ -10,9 +10,6 @@ import Data.Either
 import Data.Filter
 import Data.Foldable (fold)
 
-import Control.Monad.Eff
-import Control.Monad.Eff.Unsafe
-
 import qualified Thermite as T
 
 import qualified React as R

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -15,7 +15,6 @@ module Test.Main (main) where
 
 import Prelude
 
-import Data.Maybe
 import Data.Maybe.Unsafe
 import Data.Nullable (toMaybe)
 
@@ -29,11 +28,9 @@ import qualified React as R
 
 import qualified DOM as DOM
 import qualified DOM.HTML as DOM
-import qualified DOM.HTML.Document as DOM
 import qualified DOM.HTML.Types as DOM
 import qualified DOM.HTML.Window as DOM
 import qualified DOM.Node.ParentNode as DOM
-import qualified DOM.Node.Types as DOM
 
 -- | The main method creates the task list component, and renders it to the document body.
 main :: Eff (dom :: DOM.DOM) Unit


### PR DESCRIPTION

* I have fixed the warnings in build. In test some are still there though and I am also getting an error when running the tests (following the instructions in readme). See output below. 
* I guess the shadowing warnings can easily be fixed, but not sure if there's a naming convention for this (e.g. 1 letter abbrev or postfix with 2 or something)? 
* Not sure how to fix the wildcard warning (number 3 below).
* Also not sure what the best way is to solve the error `ReferenceError: React is not defined`

I'm happy to fix the remaining issues in another PR if you like

```
$ pulp test -r cat > html/index.js
* Building project in /Users/user/dev/codelex/purescript-thermite
psc: No files found using pattern: src/**/*.js
psc: No files found using pattern: test/**/*.js
Warning 1 of 7:

  in module Components.TaskList
  at /Users/user/dev/codelex/purescript-thermite/test/Components/TaskList.purs line 110, column 3 - line 111, column 3

    Type variable 'eff' was shadowed.

  in value declaration taskList

  See https://github.com/purescript/purescript/wiki/Error-Code-ShadowedTypeVar for more information,
  or to contribute content related to this warning.

Warning 2 of 7:

  in module Components.TaskList
  at /Users/user/dev/codelex/purescript-thermite/test/Components/TaskList.purs line 110, column 3 - line 111, column 3

    Type variable 'props' was shadowed.

  in value declaration taskList

  See https://github.com/purescript/purescript/wiki/Error-Code-ShadowedTypeVar for more information,
  or to contribute content related to this warning.

Warning 3 of 7:

  in module Components.TaskList
  at /Users/user/dev/codelex/purescript-thermite/test/Components/TaskList.purs line 112, column 9 - line 113, column 9

    Wildcard type definition has the inferred type

      Eff ( refs :: ReactRefs ( read :: Read
                              )
          , state :: ReactState ( write :: Write
                                , read :: Read
                                )
          , props :: ReactProps
          | _52
          )
      Unit


  in value declaration taskList

  See https://github.com/purescript/purescript/wiki/Error-Code-WildcardInferredType for more information,
  or to contribute content related to this warning.

Warning 4 of 7:

  in module Components.TaskList
  at /Users/user/dev/codelex/purescript-thermite/test/Components/TaskList.purs line 72, column 3 - line 73, column 3

    Type variable 'eff' was shadowed.

  in value declaration taskList

  See https://github.com/purescript/purescript/wiki/Error-Code-ShadowedTypeVar for more information,
  or to contribute content related to this warning.

Warning 5 of 7:

  in module Components.TaskList
  at /Users/user/dev/codelex/purescript-thermite/test/Components/TaskList.purs line 72, column 3 - line 73, column 3

    Type variable 'props' was shadowed.

  in value declaration taskList

  See https://github.com/purescript/purescript/wiki/Error-Code-ShadowedTypeVar for more information,
  or to contribute content related to this warning.

Warning 6 of 7:

  in module Components.TaskList
  at /Users/user/dev/codelex/purescript-thermite/test/Components/TaskList.purs line 99, column 3 - line 100, column 3

    Type variable 'eff' was shadowed.

  in value declaration taskList

  See https://github.com/purescript/purescript/wiki/Error-Code-ShadowedTypeVar for more information,
  or to contribute content related to this warning.

Warning 7 of 7:

  in module Components.TaskList
  at /Users/user/dev/codelex/purescript-thermite/test/Components/TaskList.purs line 99, column 3 - line 100, column 3

    Type variable 'props' was shadowed.

  in value declaration taskList

  See https://github.com/purescript/purescript/wiki/Error-Code-ShadowedTypeVar for more information,
  or to contribute content related to this warning.

* Build successful.
* Running tests...

/Users/user/dev/codelex/purescript-thermite/output/React/foreign.js:129
exports.renderToString = React.renderToString;
                         ^
ReferenceError: React is not defined
    at Object.<anonymous> (/Users/user/dev/codelex/purescript-thermite/output/React/foreign.js:129:26)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/user/dev/codelex/purescript-thermite/output/React/index.js:3:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
* ERROR: Subcommand terminated with error code 8
```