### PR TITLE
Create optional components using `split`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,25 @@ Here, `_1` and `_Left` embed `spec1` inside `spec`, using the left components of
 
 _focus_ is responsible for directing the various actions to the correct components, and updating the correct parts of the state.
 
+### `split`
+
+`split` is used to handle child components which might not be present, for
+example, when a parent object contains a `Maybe` state.
+
+```purescript
+type Parent = { child :: Maybe child }
+
+_child :: LensP Parent (Maybe Child)
+_child = lens _.child (_ { child = _ })
+
+_ChildAction :: PrismP ParentAction ChildAction
+
+childSpec :: Spec _ Child _ ChildAction
+
+spec :: Spec _ Parent _ ParentAction
+spec = focus _child _ChildAction $ split _Just childSpec
+```
+
 ### `foreach`
 
 Where `focus` embeds a single subcomponent inside another component, `foreach` embeds a whole collection of subcomponents.


### PR DESCRIPTION
Fixes paf31/purescript-thermite#45.

Thermite needs a convenient way to work with child components that may or may not be present.

This began its life as `maybeSpec`, but at @paf31's suggestion, it has been generalized to work with prisms.  I considered three separate names:

- `prismSpec`. This was undesirable because very few of the related
  functions in thermite have `spec` in their names.
- `refract`. This goes better with `focus`, but it felt a bit too cute,
  and it wouldn't be as self-explanatory as I'd like.
- `split`. This is another good prism-related verb, and it seems to
  read well in code examples.

I'm not attached to the name, and I will happily consider alternatives. Somebody who has more experience with Haskell lenses and prisms might be able to find something which fits better into the larger namespace?

Another open question: Should `split` take another argument to allow changing the action type using a prism?  In all the cases I can think of, this could be done easily using an associated `focus` or `match`
operation.