### PR TITLE
Rebase of 'Create optional components using `split`'

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,25 @@ Here, `_1` and `_Left` embed `spec1` inside `spec`, using the left components of
 
 _focus_ is responsible for directing the various actions to the correct components, and updating the correct parts of the state.
 
+### `split`
+
+`split` is used to handle child components which might not be present, for
+example, when a parent object contains a `Maybe` state.
+
+```purescript
+type Parent = { child :: Maybe child }
+
+_child :: LensP Parent (Maybe Child)
+_child = lens _.child (_ { child = _ })
+
+_ChildAction :: PrismP ParentAction ChildAction
+
+childSpec :: Spec _ Child _ ChildAction
+
+spec :: Spec _ Parent _ ParentAction
+spec = focus _child _ChildAction $ split _Just childSpec
+```
+
 ### `foreach`
 
 Where `focus` embeds a single subcomponent inside another component, `foreach` embeds a whole collection of subcomponents.

--- a/docs/Thermite.md
+++ b/docs/Thermite.md
@@ -199,6 +199,14 @@ match :: forall eff props state action1 action2. PrismP action2 action1 -> Spec 
 A variant of `focus` which only changes the action type, by applying a `Prism`,
 effectively matching some subset of a larger action type.
 
+#### `split`
+
+``` purescript
+split :: forall eff props state1 state2 action. PrismP state1 state2 -> Spec eff state2 props action -> Spec eff state1 props action
+```
+
+Create a component which renders an optional subcomponent.
+
 #### `foreach`
 
 ``` purescript

--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -26,6 +26,7 @@ module Thermite
   , focus
   , focusState
   , match
+  , split
   , foreach
   ) where
 
@@ -248,6 +249,28 @@ match :: forall eff props state action1 action2.
   Spec eff state props action1 ->
   Spec eff state props action2
 match prism = focus id prism
+
+-- | Create a component which renders an optional subcomponent.
+split :: forall eff props state1 state2 action.
+  PrismP state1 state2 ->
+  Spec eff state2 props action ->
+  Spec eff state1 props action
+split prism (Spec spec) = Spec
+  { performAction: performAction
+  , render: render
+  }
+  where
+  performAction :: PerformAction eff state1 props action
+  performAction a p st k =
+    case matching prism st of
+      Left _ -> pure unit
+      Right st' -> spec.performAction a p st' (k <<< over prism)
+
+  render :: Render state1 props action
+  render k p st children =
+    case matching prism st of
+      Left _ -> []
+      Right st' -> spec.render k p st' children
 
 -- | Create a component whose state is described by a list, displaying one subcomponent
 -- | for each entry in the list.


### PR DESCRIPTION
I took the patch from #46, rebased it on master, and amended to follow the recent state callback change.  Docs have also been generated.