### PR TITLE
Bump profunctor-lenses to 0.5.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "purescript-dom": "^0.2.6",
-    "purescript-profunctor-lenses": "~0.3.0",
+    "purescript-profunctor-lenses": "~0.5.0",
     "purescript-react": "^0.6.0",
     "purescript-react-dom": "^0.1.0"
   }


### PR DESCRIPTION
A person on IRC had a problem:

> i tried to install both thermite and opticUI to mess around with, but they use incompatible versions of purescript-profunctor-lenses

Here's my attempt to help by bumping the profunctor-lenses lib to latest.
I used the build and test commands in pulp with no problems, and I tested the produced html in browser.