### PR TITLE
Tweak README reference to react-dom, -'qualified'

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ Here is an example. We'll build a component which displays the value of a intege
 First of all, we need to import some modules:
 
 ```purescript
-import qualified Thermite as T
+import Thermite as T
 
-import qualified React as R
-import qualified React.DOM as R
-import qualified React.DOM.Props as RP
+import React as R
+import React.DOM as R
+import React.DOM.Props as RP
+import ReactDOM as RDOM
 ```
 
 In our component, users will be able to take two actions - increment and decrement - which will be represented as buttons later:
@@ -104,7 +105,7 @@ The `render` function from `purescript-react` can then be used to render our com
 ```purescript
 main = do
   let component = T.createClass spec initialState
-  body >>= R.render (R.createFactory component {})
+  body >>= RDOM.render (R.createFactory component {})
 ```
 
 ## Combining Components

--- a/test/Components/Task.purs
+++ b/test/Components/Task.purs
@@ -2,10 +2,10 @@ module Components.Task where
 
 import Prelude
 
-import qualified Thermite as T
+import Thermite as T
 
-import qualified React.DOM as R
-import qualified React.DOM.Props as RP
+import React.DOM as R
+import React.DOM.Props as RP
 
 import Unsafe.Coerce
 

--- a/test/Components/TaskList.purs
+++ b/test/Components/TaskList.purs
@@ -10,11 +10,11 @@ import Data.Either
 import Data.Filter
 import Data.Foldable (fold)
 
-import qualified Thermite as T
+import Thermite as T
 
-import qualified React as R
-import qualified React.DOM as R
-import qualified React.DOM.Props as RP
+import React as R
+import React.DOM as R
+import React.DOM.Props as RP
 
 import Components.Task
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -22,16 +22,16 @@ import Control.Monad.Eff
 
 import Components.TaskList
 
-import qualified Thermite as T
+import Thermite as T
 
-import qualified React as R
-import qualified ReactDOM as RDOM
+import React as R
+import ReactDOM as RDOM
 
-import qualified DOM as DOM
-import qualified DOM.HTML as DOM
-import qualified DOM.HTML.Types as DOM
-import qualified DOM.HTML.Window as DOM
-import qualified DOM.Node.ParentNode as DOM
+import DOM as DOM
+import DOM.HTML as DOM
+import DOM.HTML.Types as DOM
+import DOM.HTML.Window as DOM
+import DOM.Node.ParentNode as DOM
 
 -- | The main method creates the task list component, and renders it to the document body.
 main :: Eff (dom :: DOM.DOM) Unit


### PR DESCRIPTION
The bottom line of the inline README example needed updated to refer to `ReactDOM`. But it's not clear to  me where `body` comes from in this worked through example. And it should probably be replaced by some tag within the body (per recent react, rendering to body gives a warning).

Removed some unnecessary import syntax while I was at it.


