### PR TITLE
Use Coroutine/CoTransformer for PerformAction API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,9 @@
     "purescript-dom": "^1.0.0",
     "purescript-profunctor-lenses": "^1.0.0",
     "purescript-react": "^1.0.0",
-    "purescript-react-dom": "^1.0.0"
+    "purescript-react-dom": "^1.0.0",
+    "purescript-freet": "^1.0.0",
+    "purescript-aff": "^1.0.0",
+    "purescript-coroutines": "^1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
     "purescript-react-dom": "^1.0.0",
     "purescript-freet": "^1.0.0",
     "purescript-aff": "^1.0.0",
-    "purescript-coroutines": "^1.0.0"
+    "purescript-coroutines": "^1.3.0"
   }
 }

--- a/docs/Thermite.md
+++ b/docs/Thermite.md
@@ -15,7 +15,7 @@ Thermite also provides type class instances and lens combinators for composing `
 #### `PerformAction`
 
 ``` purescript
-type PerformAction eff state props action = action -> props -> state -> ((state -> state) -> Eff eff Unit) -> Eff eff Unit
+type PerformAction eff state props action = action -> props -> state -> Producer (state -> state) (Aff eff) Unit
 ```
 
 A type synonym for action handlers, which take an action, the current properties
@@ -219,4 +219,33 @@ for each entry in the list.
 The action type is modified to take the index of the originating subcomponent as an
 additional argument.
 
+
+### Re-exported from Control.Coroutine:
+
+#### `Producer`
+
+``` purescript
+type Producer o = Co (Emit o)
+```
+
+A type synonym for a `Co`routine which only emits values.
+
+#### `producer`
+
+``` purescript
+producer :: forall o m r. Monad m => m (Either o r) -> Producer o m r
+```
+
+Create a `Producer` by providing a monadic function that produces values.
+
+The function should pure a value of type `r` at most once, when the
+`Producer` is ready to close.
+
+#### `emit`
+
+``` purescript
+emit :: forall m o. Monad m => o -> Producer o m Unit
+```
+
+Emit an output value.
 

--- a/test/Components/Task.purs
+++ b/test/Components/Task.purs
@@ -49,5 +49,5 @@ taskSpec = T.simpleSpec performAction render
   -- _Note_: this component can only see actions of type `TaskAction`, but the `RemoveTask` action
   -- is ignored here: it will be handled by the parent component.
   performAction :: T.PerformAction eff Task props TaskAction
-  performAction (ChangeCompleted b)   _ _ k = k $ _ { completed = b }
-  performAction _                     _ _ _ = pure unit
+  performAction (ChangeCompleted b)   _ _ = T.emit (_ { completed = b })
+  performAction _                     _ _ = pure unit

--- a/test/Components/Task.purs
+++ b/test/Components/Task.purs
@@ -49,5 +49,5 @@ taskSpec = T.simpleSpec performAction render
   -- _Note_: this component can only see actions of type `TaskAction`, but the `RemoveTask` action
   -- is ignored here: it will be handled by the parent component.
   performAction :: T.PerformAction eff Task props TaskAction
-  performAction (ChangeCompleted b)   _ _ = T.emit (_ { completed = b })
+  performAction (ChangeCompleted b)   _ _ = void (T.cotransform (_ { completed = b }))
   performAction _                     _ _ = pure unit

--- a/test/Components/TaskList.purs
+++ b/test/Components/TaskList.purs
@@ -88,7 +88,7 @@ taskList = container $ fold
         -- The `NewTask` action is handled here
         -- Everything else is handled by some other child component so is ignored here.
         performAction :: T.PerformAction eff TaskListState props TaskListAction
-        performAction (NewTask s) _ _ = T.emit $ \state -> state { tasks = Cons (initialTask s) state.tasks }
+        performAction (NewTask s) _ _ = void $ T.cotransform $ \state -> state { tasks = Cons (initialTask s) state.tasks }
         performAction _           _ _ = pure unit
 
     -- This function wraps a `Spec`'s `Render` function to filter out tasks.
@@ -144,7 +144,7 @@ taskList = container $ fold
     listActions = T.simpleSpec performAction T.defaultRender
       where
       performAction :: T.PerformAction eff TaskListState props TaskListAction
-      performAction (TaskAction i RemoveTask) _ _ = T.emit \state -> state { tasks = fromMaybe state.tasks (deleteAt i state.tasks) }
-      performAction (SetEditText s)           _ _ = T.emit (_ { editText = s })
-      performAction (SetFilter f)             _ _ = T.emit (_ { filter = f })
+      performAction (TaskAction i RemoveTask) _ _ = void $ T.cotransform \state -> state { tasks = fromMaybe state.tasks (deleteAt i state.tasks) }
+      performAction (SetEditText s)           _ _ = void $ T.cotransform (_ { editText = s })
+      performAction (SetFilter f)             _ _ = void $ T.cotransform (_ { filter = f })
       performAction _                         _ _ = pure unit

--- a/test/Components/TaskList.purs
+++ b/test/Components/TaskList.purs
@@ -88,8 +88,8 @@ taskList = container $ fold
         -- The `NewTask` action is handled here
         -- Everything else is handled by some other child component so is ignored here.
         performAction :: T.PerformAction eff TaskListState props TaskListAction
-        performAction (NewTask s) _ _ k = k $ \state -> state { tasks = Cons (initialTask s) state.tasks }
-        performAction _ _ _ _ = pure unit
+        performAction (NewTask s) _ _ = T.emit $ \state -> state { tasks = Cons (initialTask s) state.tasks }
+        performAction _           _ _ = pure unit
 
     -- This function wraps a `Spec`'s `Render` function to filter out tasks.
     applyFilter :: forall action. Filter -> T.Spec eff Task props action -> T.Spec eff Task props action
@@ -144,7 +144,7 @@ taskList = container $ fold
     listActions = T.simpleSpec performAction T.defaultRender
       where
       performAction :: T.PerformAction eff TaskListState props TaskListAction
-      performAction (TaskAction i RemoveTask) _ _ k = k \state -> state { tasks = fromMaybe state.tasks (deleteAt i state.tasks) }
-      performAction (SetEditText s)           _ _ k = k $ _ { editText = s }
-      performAction (SetFilter f)             _ _ k = k $ _ { filter = f }
-      performAction _ _ _ _ = pure unit
+      performAction (TaskAction i RemoveTask) _ _ = T.emit \state -> state { tasks = fromMaybe state.tasks (deleteAt i state.tasks) }
+      performAction (SetEditText s)           _ _ = T.emit (_ { editText = s })
+      performAction (SetFilter f)             _ _ = T.emit (_ { filter = f })
+      performAction _                         _ _ = pure unit


### PR DESCRIPTION
@pkamenarsky I've reverted back to the `Producer (s -> s)` approach, for the reasons given in your PR. Could you please have a look at this, and let me know what you think?

If this looks okay, I'll make a 1.0 release.

Thanks!