### PR TITLE
add qualifier to defaultMain function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ spec = T.simpleSpec performAction render
 Finally, in `main`, the `defaultMain` function can be used to render our component to the document body by specifying the initial state:
 
 ```purescript
-main = defaultMain spec initialState unit
+main = T.defaultMain spec initialState unit
 ```
 
 ## Combining Components


### PR DESCRIPTION
`defaultMain` is located in the Thermite module which was imported qualified as T.