### PR TITLE
Export Spec constructor

### DIFF
--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -18,7 +18,7 @@ module Thermite
   , defaultRender
   , writeState
   , modifyState
-  , Spec
+  , Spec(..)
   , _performAction
   , _render
   , simpleSpec


### PR DESCRIPTION
I am not really sure how this is useful, since this can be done on the level of `ReactSpec`s and also `ReactClass`es, but if  `Spec` constructor is exported then one can turn `Spec` into contravariant functor:
```
import Thermite as T

mapPropsTSpec
  :: forall props props' state action eff
   . (props' -> props)
  -> T.Spec eff state props action
  -> T.Spec eff state props' action
mapPropsTSpec f (T.Spec sp) = T.simpleSpec performAction render
  where
    performAction a p = sp.performAction a (f p)
    render a p = sp.render a (f p)
```

Or maybe just include this instance of `Contravariant` into `Thermite`.