### PR TITLE
corrected dependencies typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "pulp build -- --censor-lib --strict",
     "example": "pulp test -r cat > html/index.js"
   },
-  "dependnecies": {
+  "dependencies": {
     "react": "^0.14.7",
     "react-dom": "^0.14.7"
   },


### PR DESCRIPTION
Thanks for all your work on this repo. The typo in package.json prevents the `react` and `react-dom` packages from installing, which prevents the sample app from working.

This PR fixes the installation dependencies. It might be worth adding an `npm install` step to the `Building` section of the Readme file. btw, `npm test` doesn't work right now. I can create PRs for those issues if it's helpful