### PR TITLE
Update to purescript-aff 4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/paf31/purescript-thermite.git"
   },
   "dependencies": {
-    "purescript-aff": "^3.0.0",
+    "purescript-aff": "^4.0.0",
     "purescript-coroutines": "^4.0.0",
     "purescript-dom": "^4.0.0",
     "purescript-freet": "^3.0.0",


### PR DESCRIPTION
This PR updates the library to work with purescript-aff version 4. The only change required seems to be in a call to `makeAff` which now takes a single callback combining what was previously done in two, also the result of the `Eff` computation is now supposed to be a `Canceler` (https://pursuit.purescript.org/packages/purescript-aff/4.0.0/docs/Control.Monad.Aff#t:Canceler) -- I have used `nonCanceler` (does nothing) as I did not find anything that could be done at that point.