### PR TITLE
Add method withProps

### DIFF
--- a/generated-docs/Thermite.md
+++ b/generated-docs/Thermite.md
@@ -205,6 +205,14 @@ This function captures the state of the `Spec` as a function argument.
 This can sometimes be useful in complex scenarios involving the `focus` and
 `foreach` combinators.
 
+#### `withProps`
+
+``` purescript
+withProps :: forall eff state props action. (props -> Spec eff state props action) -> Spec eff state props action
+```
+
+This function captures the props of the `Spec` as a function argument.
+
 #### `focus`
 
 ``` purescript

--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -27,6 +27,7 @@ module Thermite
   , createReactSpec'
   , defaultMain
   , withState
+  , withProps
   , focus
   , focusState
   , match

--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -301,6 +301,19 @@ withState f = simpleSpec performAction render
     render :: Render state props action
     render k p st = view _render (f st) k p st
 
+-- | This function captures the props of the `Spec` as a function argument.
+withProps
+  :: forall eff state props action
+   . (props -> Spec eff state props action)
+  -> Spec eff state props action
+withProps f = simpleSpec performAction render
+  where
+    performAction :: PerformAction eff state props action
+    performAction a p st = view _performAction (f p) a p st
+
+    render :: Render state props action
+    render k p st = view _render (f p) k p st
+
 -- | Change the state type, using a lens to focus on a part of the state.
 -- |
 -- | For example, to combine two `Spec`s, combining state types using `Tuple`


### PR DESCRIPTION
It would be easier to use props with this function. For example, to choose spec according to property or to pass property as argument to another function. It is mirror implementation of `witState` function.