### PR TITLE
Upgrade to v0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /node_modules/
 /bower_components/
 /tmp/
-/example/index.js
+/html/index.js
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 sudo: required
-node_js: 6
+node_js: 10
 install:
   - npm install -g bower
   - npm install

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,9 @@
     "purescript-freet": "^3.0.0",
     "purescript-profunctor-lenses": "^3.0.0",
     "purescript-react-dom": "^4.0.0",
-    "purescript-react": "^4.0.0"
+    "purescript-react": "^5.0.1"
+  },
+  "resolutions": {
+    "purescript-react": "^5.0.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -16,15 +16,15 @@
     "url": "git://github.com/paf31/purescript-thermite.git"
   },
   "dependencies": {
-    "purescript-aff": "^4.0.0",
-    "purescript-coroutines": "^4.0.0",
-    "purescript-dom": "^4.0.0",
-    "purescript-freet": "^3.0.0",
-    "purescript-profunctor-lenses": "^3.0.0",
-    "purescript-react-dom": "^4.0.0",
-    "purescript-react": "^5.0.1"
+    "purescript-aff": "^5.0.2",
+    "purescript-coroutines": "^5.0.0",
+    "purescript-web-html": "^1.2.0",
+    "purescript-freet": "^4.0.0",
+    "purescript-profunctor-lenses": "^5.0.0",
+    "purescript-react-dom": "^6.0.0",
+    "purescript-react": "^6.1.0"
   },
   "resolutions": {
-    "purescript-react": "^5.0.1"
+    "purescript-react": "^6.1.0"
   }
 }

--- a/generated-docs/Thermite.md
+++ b/generated-docs/Thermite.md
@@ -15,7 +15,7 @@ Thermite also provides type class instances and lens combinators for composing `
 #### `PerformAction`
 
 ``` purescript
-type PerformAction eff state props action = action -> props -> state -> CoTransformer (Maybe state) (state -> state) (Aff eff) Unit
+type PerformAction state props action = action -> props -> state -> CoTransformer (Maybe state) (state -> state) Aff Unit
 ```
 
 A type synonym for an action handler, which takes an action, the current props
@@ -30,40 +30,23 @@ in certain use cases involving `split` and `foreach`.
 #### `defaultPerformAction`
 
 ``` purescript
-defaultPerformAction :: forall eff state props action. PerformAction eff state props action
+defaultPerformAction :: forall state props action. PerformAction state props action
 ```
 
 A default `PerformAction` action implementation which ignores all actions.
 
-#### `writeState`
+#### `Dispatch`
 
 ``` purescript
-writeState :: forall state eff. state -> CoTransformer (Maybe state) (state -> state) (Aff eff) (Maybe state)
+type Dispatch action = action -> Effect Unit
 ```
 
-Replace the current component state.
-
-#### `modifyState`
-
-``` purescript
-modifyState :: forall state eff. (state -> state) -> CoTransformer (Maybe state) (state -> state) (Aff eff) (Maybe state)
-```
-
-An alias for `cotransform` - apply a function to the current component state.
-
-#### `EventHandler`
-
-``` purescript
-type EventHandler = forall eff refs. Eff (props :: ReactProps, state :: ReactState ReadWrite, refs :: ReactRefs refs | eff) Unit
-```
-
-A type synonym for an event handler which can be used to construct
-`purescript-react`'s event attributes.
+A type synonym for a `dispatch`able function of action types.
 
 #### `Render`
 
 ``` purescript
-type Render state props action = (action -> EventHandler) -> props -> state -> Array ReactElement -> Array ReactElement
+type Render state props action = Dispatch action -> props -> state -> Array ReactElement -> Array ReactElement
 ```
 
 A rendering function, which takes an action handler function, the current state and
@@ -79,10 +62,26 @@ A default `Render` implementation which renders nothing.
 
 This is useful when just `append`ing action handlers.
 
+#### `writeState`
+
+``` purescript
+writeState :: forall state. state -> CoTransformer (Maybe state) (state -> state) Aff (Maybe state)
+```
+
+Replace the current component state.
+
+#### `modifyState`
+
+``` purescript
+modifyState :: forall state. (state -> state) -> CoTransformer (Maybe state) (state -> state) Aff (Maybe state)
+```
+
+An alias for `cotransform` - apply a function to the current component state.
+
 #### `Spec`
 
 ``` purescript
-newtype Spec eff state props action
+newtype Spec state props action
 ```
 
 A component specification, which can be passed to `createClass`.
@@ -94,14 +93,14 @@ HTML elements next to one another, and performing actions in sequence.
 
 ##### Instances
 ``` purescript
-Semigroup (Spec eff state props action)
-Monoid (Spec eff state props action)
+Semigroup (Spec state props action)
+Monoid (Spec state props action)
 ```
 
 #### `_performAction`
 
 ``` purescript
-_performAction :: forall eff state props action. Lens' (Spec eff state props action) (PerformAction eff state props action)
+_performAction :: forall state props action. Lens' (Spec state props action) (PerformAction state props action)
 ```
 
 A `Lens` for accessing the `PerformAction` portion of a `Spec`.
@@ -109,7 +108,7 @@ A `Lens` for accessing the `PerformAction` portion of a `Spec`.
 #### `_render`
 
 ``` purescript
-_render :: forall eff state props action. Lens' (Spec eff state props action) (Render state props action)
+_render :: forall state props action. Lens' (Spec state props action) (Render state props action)
 ```
 
 A `Lens` for accessing the `Render` portion of a `Spec`.
@@ -118,7 +117,7 @@ This can be useful when wrapping a `Render` function in order to frame a
 set of controls with some containing element. For example:
 
 ```purescript
-wrap :: Spec _ State _ Action -> Spec _ State _ Action
+wrap :: Spec State _ Action -> Spec State _ Action
 wrap = over _render \child dispatch props state childre  ->
   [ R.div [ RP.className "wrapper" ] [ child dispatch props state children ] ]
 ```
@@ -126,7 +125,7 @@ wrap = over _render \child dispatch props state childre  ->
 #### `simpleSpec`
 
 ``` purescript
-simpleSpec :: forall eff state props action. PerformAction eff state props action -> Render state props action -> Spec eff state props action
+simpleSpec :: forall state props action. PerformAction state props action -> Render state props action -> Spec state props action
 ```
 
 Create a minimal `Spec`. The arguments are, in order:
@@ -141,54 +140,42 @@ import qualified React.DOM as R
 
 data Action = Increment
 
-spec :: Spec _ Int _ Action
+spec :: Spec Int _ Action
 spec = simpleSpec performAction render
   where
   render :: Render _ Int _
   render _ _ n _ = [ R.text (show n) ]
 
-  performAction :: PerformAction _ Int _ Action
+  performAction :: PerformAction Int _ Action
   performAction Increment _ n k = k (n + 1)
 ```
 
 #### `createClass`
 
 ``` purescript
-createClass :: forall eff state props action. Spec eff state props action -> state -> ReactClass props
+createClass :: forall state props action. Spec {  | state } { children :: Children | props } action -> {  | state } -> String -> ReactClass { children :: Children | props }
 ```
 
 Create a React component class from a Thermite component `Spec`.
 
-#### `createReactSpec`
+#### `createReactConstructor`
 
 ``` purescript
-createReactSpec :: forall eff state props action. Spec eff state props action -> state -> { spec :: ReactSpec props state eff, dispatcher :: ReactThis props state -> action -> EventHandler }
+createReactConstructor :: forall state props action. Spec {  | state } { children :: Children | props } action -> {  | state } -> { constructor :: ReactClassConstructor { children :: Children | props } {  | state } (render :: Render, state :: {  | state }), dispatcher :: ReactThis { children :: Children | props } {  | state } -> Dispatch action }
 ```
 
-Create a React component spec from a Thermite component `Spec`.
-
-This function is a low-level alternative to `createClass`, used when the React
-component spec needs to be modified before being turned into a component class,
-e.g. by adding additional lifecycle methods.
-
-#### `createReactSpec'`
-
-``` purescript
-createReactSpec' :: forall eff state props action. (Array ReactElement -> ReactElement) -> Spec eff state props action -> state -> { spec :: ReactSpec props state eff, dispatcher :: ReactThis props state -> action -> EventHandler }
-```
-
-Create a React component spec from a Thermite component `Spec` with an additional
+Create a React component constructor from a Thermite component `Spec` with an additional
 function for converting the rendered Array of ReactElement's into a single ReactElement
 as is required by React.
 
 This function is a low-level alternative to `createClass`, used when the React
-component spec needs to be modified before being turned into a component class,
+component constructor needs to be modified before being turned into a component class,
 e.g. by adding additional lifecycle methods.
 
 #### `defaultMain`
 
 ``` purescript
-defaultMain :: forall state props action eff. Spec eff state props action -> state -> props -> Eff (dom :: DOM | eff) Unit
+defaultMain :: forall state props given action. ReactPropFields props given => Spec {  | state } { children :: Children | props } action -> {  | state } -> String -> {  | given } -> Effect Unit
 ```
 
 A default implementation of `main` which renders a component to the
@@ -197,7 +184,7 @@ document body.
 #### `withState`
 
 ``` purescript
-withState :: forall eff state props action. (state -> Spec eff state props action) -> Spec eff state props action
+withState :: forall state props action. (state -> Spec state props action) -> Spec state props action
 ```
 
 This function captures the state of the `Spec` as a function argument.
@@ -208,7 +195,7 @@ This can sometimes be useful in complex scenarios involving the `focus` and
 #### `focus`
 
 ``` purescript
-focus :: forall eff props state2 state1 action1 action2. Lens' state2 state1 -> Prism' action2 action1 -> Spec eff state1 props action1 -> Spec eff state2 props action2
+focus :: forall props state2 state1 action1 action2. Lens' state2 state1 -> Prism' action2 action1 -> Spec state1 props action1 -> Spec state2 props action2
 ```
 
 Change the state type, using a lens to focus on a part of the state.
@@ -217,10 +204,10 @@ For example, to combine two `Spec`s, combining state types using `Tuple`
 and action types using `Either`:
 
 ```purescript
-spec1 :: Spec _ S1 _ A1
-spec2 :: Spec _ S2 _ A2
+spec1 :: Spec S1 _ A1
+spec2 :: Spec S2 _ A2
 
-spec :: Spec _ (Tuple S1 S2) _ (Either A1 A2)
+spec :: Spec (Tuple S1 S2) _ (Either A1 A2)
 spec = focus _1 _Left spec1 <> focus _2 _Right spec2
 ```
 
@@ -230,7 +217,7 @@ the action will be ignored, and should be handled by some other component.
 #### `focusState`
 
 ``` purescript
-focusState :: forall eff props state2 state1 action. Lens' state2 state1 -> Spec eff state1 props action -> Spec eff state2 props action
+focusState :: forall props state2 state1 action. Lens' state2 state1 -> Spec state1 props action -> Spec state2 props action
 ```
 
 A variant of `focus` which only changes the state type, by applying a `Lens`.
@@ -238,7 +225,7 @@ A variant of `focus` which only changes the state type, by applying a `Lens`.
 #### `match`
 
 ``` purescript
-match :: forall eff props state action1 action2. Prism' action2 action1 -> Spec eff state props action1 -> Spec eff state props action2
+match :: forall props state action1 action2. Prism' action2 action1 -> Spec state props action1 -> Spec state props action2
 ```
 
 A variant of `focus` which only changes the action type, by applying a `Prism`,
@@ -247,7 +234,7 @@ effectively matching some subset of a larger action type.
 #### `split`
 
 ``` purescript
-split :: forall eff props state1 state2 action. Prism' state1 state2 -> Spec eff state2 props action -> Spec eff state1 props action
+split :: forall props state1 state2 action. Prism' state1 state2 -> Spec state2 props action -> Spec state1 props action
 ```
 
 Create a component which renders an optional subcomponent.
@@ -255,7 +242,7 @@ Create a component which renders an optional subcomponent.
 #### `foreach`
 
 ``` purescript
-foreach :: forall eff props state action. (Int -> Spec eff state props action) -> Spec eff (List state) props (Tuple Int action)
+foreach :: forall props state action. (Int -> Spec state props action) -> Spec (List state) props (Tuple Int action)
 ```
 
 Create a component whose state is described by a list, displaying one subcomponent
@@ -263,6 +250,12 @@ for each entry in the list.
 
 The action type is modified to take the index of the originating subcomponent as an
 additional argument.
+
+#### `cmapProps`
+
+``` purescript
+cmapProps :: forall state props props' action. (props' -> props) -> Spec state props action -> Spec state props' action
+```
 
 
 ### Re-exported from Control.Coroutine:

--- a/generated-docs/Thermite.md
+++ b/generated-docs/Thermite.md
@@ -52,6 +52,14 @@ type Render state props action = Dispatch action -> props -> state -> Array Reac
 A rendering function, which takes an action handler function, the current state and
 props, an array of child nodes and returns a HTML document.
 
+#### `WithChildren`
+
+``` purescript
+type WithChildren props = { children :: Children | props }
+```
+
+Convenience type when specifying the type of a `Spec`.
+
 #### `defaultRender`
 
 ``` purescript
@@ -153,7 +161,7 @@ spec = simpleSpec performAction render
 #### `createClass`
 
 ``` purescript
-createClass :: forall state props action. Spec {  | state } { children :: Children | props } action -> {  | state } -> String -> ReactClass { children :: Children | props }
+createClass :: forall state props action. Spec {  | state } (WithChildren props) action -> {  | state } -> String -> ReactClass (WithChildren props)
 ```
 
 Create a React component class from a Thermite component `Spec`.
@@ -161,7 +169,7 @@ Create a React component class from a Thermite component `Spec`.
 #### `createReactConstructor`
 
 ``` purescript
-createReactConstructor :: forall state props action. Spec {  | state } { children :: Children | props } action -> {  | state } -> { constructor :: ReactClassConstructor { children :: Children | props } {  | state } (render :: Render, state :: {  | state }), dispatcher :: ReactThis { children :: Children | props } {  | state } -> Dispatch action }
+createReactConstructor :: forall state props action. Spec {  | state } (WithChildren props) action -> {  | state } -> { constructor :: ReactClassConstructor (WithChildren props) {  | state } (render :: Render, state :: {  | state }), dispatcher :: ReactThis (WithChildren props) {  | state } -> Dispatch action }
 ```
 
 Create a React component constructor from a Thermite component `Spec` with an additional
@@ -175,7 +183,7 @@ e.g. by adding additional lifecycle methods.
 #### `defaultMain`
 
 ``` purescript
-defaultMain :: forall state props given action. ReactPropFields props given => Spec {  | state } { children :: Children | props } action -> {  | state } -> String -> {  | given } -> Effect Unit
+defaultMain :: forall state props given action. ReactPropFields props given => Spec {  | state } (WithChildren props) action -> {  | state } -> String -> {  | given } -> Effect Unit
 ```
 
 A default implementation of `main` which renders a component to the

--- a/html/index.html
+++ b/html/index.html
@@ -4,6 +4,7 @@
     <title>Thermite Example</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
 
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet" type="text/css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.5/paper/bootstrap.css" rel="stylesheet" type="text/css">

--- a/html/index.html
+++ b/html/index.html
@@ -9,8 +9,8 @@
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet" type="text/css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.5/paper/bootstrap.css" rel="stylesheet" type="text/css">
 
-    <script src="../node_modules/react/dist/react.js"></script>
-    <script src="../node_modules/react-dom/dist/react-dom.js"></script>
+    <script src="../node_modules/react/umd/react.development.js"></script>
+    <script src="../node_modules/react-dom/umd/react-dom.development.js"></script>
     <script type="text/javascript">
       function require(name) {
         if (name === 'react') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4301 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
+    "acorn": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+      "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+      "dev": true
+    },
+    "acorn-dynamic-import": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
+      "dev": true
+    },
+    "acorn-node": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.6.2.tgz",
+      "integrity": "sha512-rIhNEZuNI8ibQcL7ANm/mGyPukIaZsRNX9psFNQURyJW0nu6k8wjSDld20z6v2mDBWqX13pIEnk9gGZJHIlEXg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.2",
+        "acorn-dynamic-import": "^4.0.0",
+        "acorn-walk": "^6.1.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "acorn-walk": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
+      }
+    },
+    "app-cache-dir": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/app-cache-dir/-/app-cache-dir-0.2.1.tgz",
+      "integrity": "sha512-UdSjcARK1TxWteoGRl66MO5VRwc3uOe+rt3HmH95c+PUasN82PuDLBtmpNQ8+uoqFoUs8KJOtNv5PXgkIqEdCw==",
+      "dev": true,
+      "requires": {
+        "inspect-with-kind": "^1.0.2"
+      }
+    },
+    "append-type": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/append-type/-/append-type-1.0.2.tgz",
+      "integrity": "sha512-hac740vT/SAbrFBLgLIWZqVT5PUAcGTWS5UkDDhr+OCizZSw90WKw6sWAEgGaYd2viIblggypMXwpjzHXOvAQg==",
+      "dev": true
+    },
+    "arch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+      "dev": true
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        }
+      }
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
+      "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
+      "dev": true
+    },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browser-pack": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
+      }
+    },
+    "browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
+      }
+    },
+    "browserify": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.3.0.tgz",
+      "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.0.3",
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^1.11.0",
+        "browserify-zlib": "~0.1.2",
+        "buffer": "^4.1.0",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "~1.5.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.0",
+        "domain-browser": "~1.1.0",
+        "duplexer2": "~0.1.2",
+        "events": "~1.1.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "~0.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.0.0",
+        "labeled-stream-splicer": "^2.0.0",
+        "module-deps": "^4.0.8",
+        "os-browserify": "~0.1.1",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^2.0.0",
+        "stream-http": "^2.0.0",
+        "string_decoder": "~0.10.0",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "~0.0.0",
+        "url": "~0.11.0",
+        "util": "~0.10.1",
+        "vm-browserify": "~0.0.1",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+          "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+          "dev": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        }
+      }
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "browserify-cache-api": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cache-api/-/browserify-cache-api-3.0.1.tgz",
+      "integrity": "sha1-liR+hT8Gj9bg1FzHPwuyzZd47wI=",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "browserify-incremental": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-incremental/-/browserify-incremental-3.1.1.tgz",
+      "integrity": "sha1-BxPLdYckemMqnwjPG9FpuHi2Koo=",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^0.10.0",
+        "browserify-cache-api": "^3.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "JSONStream": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+          "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "0.0.5",
+            "through": ">=2.2.7 <3"
+          }
+        },
+        "jsonparse": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
+          "dev": true
+        }
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "dev": true,
+      "requires": {
+        "pako": "~0.2.0"
+      }
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "build-purescript": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/build-purescript/-/build-purescript-0.1.1.tgz",
+      "integrity": "sha512-f6zuH9SV9m105gFWL0OHslwPuX7OdfEpFE6sSfq7Ai7bZbe35O+sN7hovBwO3uCvU2FMMrKoHUtO8ukEfgUq9Q==",
+      "dev": true,
+      "requires": {
+        "download-purescript-source": "^0.3.2",
+        "feint": "^1.0.1",
+        "graceful-fs": "^4.1.11",
+        "inspect-with-kind": "^1.0.4",
+        "is-plain-obj": "^1.1.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "rimraf": "^2.6.2",
+        "spawn-stack": "0.3.1-0 ",
+        "uid2": "^0.0.3",
+        "zen-observable": "^0.6.0"
+      }
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "cached-path-relative": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
+      "dev": true
+    },
+    "cancelable-pump": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cancelable-pump/-/cancelable-pump-0.2.0.tgz",
+      "integrity": "sha1-hlZl1MI6aXiNS830mNt0DxsjDVc=",
+      "dev": true,
+      "requires": {
+        "pump": "^1.0.2"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chokidar": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.0.tgz",
+      "integrity": "sha512-5t6G2SH8eO6lCvYOoUpaRnF5Qfd//gd7qJAkwRUw9qlGVkiQ13uwQngqbWWaurOsaAm9+kUGbITADxt6H0XFNQ==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.0"
+      }
+    },
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "clean-stack": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
+      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "dev": true
+    },
+    "combine-source-map": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+      "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
+      }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "create-ecdh": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "create-react-class": {
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+      "requires": {
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "deps-sort": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "detective": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
+      }
+    },
+    "diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "dl-tar": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/dl-tar/-/dl-tar-0.5.3.tgz",
+      "integrity": "sha512-4e0DMD0uVz8z1nC44MvJRDyAI9FS6Q1ROzECdvB+nB3SrSOjbPJ2IPLSNhyqlz9QoQg9fqAitsFbwBLyNXCrCw==",
+      "dev": true,
+      "requires": {
+        "cancelable-pump": "^0.2.0",
+        "graceful-fs": "^4.1.11",
+        "inspect-with-kind": "^1.0.4",
+        "is-plain-obj": "^1.1.0",
+        "is-stream": "^1.1.0",
+        "load-request-from-cwd-or-npm": "^2.0.1",
+        "tar-fs": "^1.16.0",
+        "tar-stream": "^1.5.5",
+        "zen-observable": "^0.6.0"
+      }
+    },
+    "dl-tgz": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/dl-tgz/-/dl-tgz-0.5.1.tgz",
+      "integrity": "sha512-EHTJROgl6wtka3fNkKJwuz2Q+id0sCIJ3ZXF7GXRbNJAcgyrkEg9dNzmvte7TnScvzDDOPD80q8n+GyjWrHd+A==",
+      "dev": true,
+      "requires": {
+        "dl-tar": "^0.5.2",
+        "is-plain-obj": "^1.1.0",
+        "zen-observable": "^0.6.0"
+      }
+    },
+    "domain-browser": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+      "dev": true
+    },
+    "download-or-build-purescript": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/download-or-build-purescript/-/download-or-build-purescript-0.0.7.tgz",
+      "integrity": "sha512-Zgerb2bptzdKGY3shw9PFE/riK7L8kK6/rMmrTWui4+nG64pH4eHHu55qPSeGt7/81Feur5i/hRsVMyo5yjh8g==",
+      "dev": true,
+      "requires": {
+        "build-purescript": "^0.1.0",
+        "download-purescript": "^0.3.0",
+        "execa": "^0.7.0",
+        "feint": "1.0.1",
+        "graceful-fs": "^4.1.11",
+        "inspect-with-kind": "^1.0.3",
+        "is-plain-obj": "^1.1.0",
+        "once": "^1.4.0",
+        "prepare-write": "^0.3.0",
+        "spawn-stack": "0.3.1-0",
+        "which": "^1.3.0",
+        "zen-observable": "^0.6.0"
+      }
+    },
+    "download-purescript": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/download-purescript/-/download-purescript-0.3.3.tgz",
+      "integrity": "sha512-miZR+nufWL1dbJd6sfFlI7WA0FguFNo8o11tEW1qnsGLD+ClhfF8jaUDyPbcrbD5CSgUBfB6a5JTumGFts+rLg==",
+      "dev": true,
+      "requires": {
+        "dl-tgz": "^0.5.1",
+        "inspect-with-kind": "^1.0.4",
+        "is-plain-obj": "^1.1.0",
+        "zen-observable": "^0.6.1"
+      }
+    },
+    "download-purescript-source": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/download-purescript-source/-/download-purescript-source-0.3.2.tgz",
+      "integrity": "sha512-Vt9gH6IOrrRnsSbjIrMWtKt86VYoYYyQQMF7mvweLDop99QJPolYcpsURyFxbT2GoLjwqI4L6l47dn5hzu/t4A==",
+      "dev": true,
+      "requires": {
+        "dl-tgz": "^0.5.1",
+        "inspect-with-kind": "^1.0.4",
+        "is-plain-obj": "^1.1.0",
+        "zen-observable": "^0.6.1"
+      }
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "elliptic": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "executing-npm-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/executing-npm-path/-/executing-npm-path-0.1.0.tgz",
+      "integrity": "sha512-NG/Pw0xD4KBcb5ilpZa57n7U17obIvZX1TCBLdv9M7Jd3wSsfU8BtMSy+EFkx9hhJsnIBBEmaPQd12dXWaxlHA==",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      }
+    },
+    "feint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/feint/-/feint-1.0.1.tgz",
+      "integrity": "sha1-FsZCrfN+vzSHjy64MY96X71si5w=",
+      "dev": true,
+      "requires": {
+        "append-type": "^1.0.0"
+      }
+    },
+    "file-to-tar": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/file-to-tar/-/file-to-tar-0.2.3.tgz",
+      "integrity": "sha512-nFcPj8HwSRdqxLX4Fja7oCzQOSQSrS1iCnJZDMn+i2MvW+wXh4uoUPLE9NlUUdMAsmXoG8oTFalXBf6V66g6hA==",
+      "dev": true,
+      "requires": {
+        "cancelable-pump": "^0.2.0",
+        "graceful-fs": "^4.1.11",
+        "inspect-with-kind": "^1.0.4",
+        "is-plain-obj": "^1.1.0",
+        "is-stream": "^1.1.0",
+        "mkdirp": "^0.5.1",
+        "tar-fs": "^1.16.0",
+        "zen-observable": "^0.6.1"
+      }
+    },
+    "filesize": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-assigned-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "htmlescape": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
+      "dev": true
+    },
+    "https-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ieee754": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inline-source-map": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.5.3"
+      }
+    },
+    "insert-module-globals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
+      "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.0.3",
+        "acorn-node": "^1.5.2",
+        "combine-source-map": "^0.8.0",
+        "concat-stream": "^1.6.1",
+        "is-buffer": "^1.1.0",
+        "path-is-absolute": "^1.0.1",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "undeclared-identifiers": "^1.1.2",
+        "xtend": "^4.0.0"
+      }
+    },
+    "inspect-with-kind": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/inspect-with-kind/-/inspect-with-kind-1.0.5.tgz",
+      "integrity": "sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
+    "install-purescript": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/install-purescript/-/install-purescript-0.2.1.tgz",
+      "integrity": "sha512-ehbjJr5GnOOcyUfAXYiHD471NV+QTNuIY8piDhg4YcgBFFqf05QQbAOd+oyoRdJtLGsuTbJdnAEdDh3fvnDb9g==",
+      "dev": true,
+      "requires": {
+        "app-cache-dir": "^0.2.1",
+        "arch": "^2.1.0",
+        "download-or-build-purescript": "^0.0.7",
+        "execa": "^0.7.0",
+        "feint": "1.0.1",
+        "file-to-tar": "^0.2.2",
+        "graceful-fs": "^4.1.11",
+        "inspect-with-kind": "^1.0.4",
+        "is-plain-obj": "^1.1.0",
+        "once": "^1.4.0",
+        "prepare-write": "^0.3.1",
+        "readdir-clean": "^0.4.0",
+        "rimraf": "^2.6.2",
+        "tar-to-file": "^0.2.0",
+        "tilde-path": "^2.0.0",
+        "truncated-list": "^0.1.0",
+        "zen-observable": "^0.6.0"
+      }
+    },
+    "install-purescript-cli": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/install-purescript-cli/-/install-purescript-cli-0.2.1.tgz",
+      "integrity": "sha512-4QbrfCeYAwfCRbmx+5UxFl6IYRGKPYKy+UxnZDkYvE0LM7uput/RfEUym5GzCwG8ra6DbtgXfEaQVl3tMstfJw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "install-purescript": "^0.2.0",
+        "log-symbols": "^2.2.0",
+        "log-update": "^2.3.0",
+        "minimist": "^1.2.0",
+        "ms": "^2.1.1",
+        "neat-frame": "^0.2.0",
+        "neat-stack": "^0.1.2",
+        "once": "^1.4.0",
+        "platform-name": "^0.6.1",
+        "size-rate": "^0.1.0",
+        "tilde-path": "^2.0.0",
+        "tty-truncate": "^0.3.1",
+        "vertical-meter": "^0.2.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-dir/-/is-dir-1.0.0.tgz",
+      "integrity": "sha1-QdN/SV/MrMBaR3jWboMCTCkro/8=",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "json-stable-stringify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
+    },
+    "junk": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-2.1.0.tgz",
+      "integrity": "sha1-9DG0t/By3FAKXxDOf07HGTDnATQ=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "labeled-stream-splicer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "isarray": "^2.0.4",
+        "stream-splicer": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
+          "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA==",
+          "dev": true
+        }
+      }
+    },
+    "load-from-cwd-or-npm": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/load-from-cwd-or-npm/-/load-from-cwd-or-npm-2.2.2.tgz",
+      "integrity": "sha512-Ox0Cl1RfKMKrwqhBqYADWeFspY28bhlaJVe08GJqYtVYoE0kyAnWBOnw3V/+HDoeWb7o33X/ZUcvamIlJ4O4Gg==",
+      "dev": true,
+      "requires": {
+        "inspect-with-kind": "^1.0.4",
+        "npm-cli-dir": "^2.0.1",
+        "optional": "^0.1.4",
+        "resolve-from-npm": "^2.0.4"
+      }
+    },
+    "load-request-from-cwd-or-npm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/load-request-from-cwd-or-npm/-/load-request-from-cwd-or-npm-2.0.1.tgz",
+      "integrity": "sha512-RMDblVBrhyatt2KBScYzbPZrg2KGOryEdcAXIF3Jh3nqcE1awqUtJABwkPv1UrC802QFFxn/mn10m9dHN+fXrQ==",
+      "dev": true,
+      "requires": {
+        "load-from-cwd-or-npm": "^2.2.1"
+      }
+    },
+    "lodash.memoize": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "log-update": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "module-deps": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+      "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.0.3",
+        "browser-resolve": "^1.7.0",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "~1.5.0",
+        "defined": "^1.0.0",
+        "detective": "^4.0.0",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.3",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+          "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+          "dev": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "neat-frame": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/neat-frame/-/neat-frame-0.2.0.tgz",
+      "integrity": "sha512-7GOJQFq7MUJNMsYFfJ4Uk7Mi0MtIpX8xxtoP+zRuOoazTmHckvDCcGa6oRR6YwvmG+TIQSrkmIgolxAXM+2k8Q==",
+      "dev": true,
+      "requires": {
+        "inspect-with-kind": "^1.0.2",
+        "string-width": "^2.1.1",
+        "term-size": "^1.2.0",
+        "wrap-ansi": "^3.0.1"
+      }
+    },
+    "neat-stack": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/neat-stack/-/neat-stack-0.1.2.tgz",
+      "integrity": "sha512-IM2Xfjma9Czp1FkFZBQVWm36156RFcpm7s4oWCmPqsD44RdgHSA3YtJykkQIpTHGFkVVWEpG811HUUB5e/kkLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "clean-stack": "^1.3.0"
+      }
+    },
+    "neo-async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node-static": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.11.tgz",
+      "integrity": "sha512-zfWC/gICcqb74D9ndyvxZWaI1jzcoHmf4UTHWQchBNuNMxdBLJMDiUgZ1tjGLEIe/BMhj2DxKD8HOuc2062pDQ==",
+      "dev": true,
+      "requires": {
+        "colors": ">=0.6.0",
+        "mime": "^1.2.9",
+        "optimist": ">=0.3.4"
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "npm-cli-dir": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-cli-dir/-/npm-cli-dir-2.0.2.tgz",
+      "integrity": "sha512-ibO7mB5Na7yv4fFTi39y3dKeK0D51ttyldqqOZKR9GU0Qwr0FFycQhXIliwqzNCVRkNi/iTG0D9WIVt7pP+vGQ==",
+      "dev": true,
+      "requires": {
+        "npm-cli-path": "^2.0.1"
+      }
+    },
+    "npm-cli-path": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/npm-cli-path/-/npm-cli-path-2.0.5.tgz",
+      "integrity": "sha512-Mdd8f1l0o7KUkL8Mty5XbaJVD6hQ/Kq10AFgyjhHg6d/0KHXc4p/O6hPWXSmoJ/RXyzPKIqDCXM1zq46i+Yfeg==",
+      "dev": true,
+      "requires": {
+        "executing-npm-path": "^0.1.0",
+        "real-executable-path": "^2.0.2",
+        "win-user-installed-npm-cli-path": "^2.0.2"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optional": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
+      "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
+      "dev": true
+    },
+    "os-browserify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "dev": true
+    },
+    "parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+      "dev": true,
+      "requires": {
+        "path-platform": "~0.11.15"
+      }
+    },
+    "parse-asn1": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
+      "integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
+      "dev": true,
+      "requires": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+      "dev": true
+    },
+    "pbkdf2": {
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "dev": true,
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "platform-name": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/platform-name/-/platform-name-0.6.1.tgz",
+      "integrity": "sha512-2ZCglHx00s/cQ6CK27tB6gh6WYO6Rm1caXihLUg0+wqLslUvWKBoOSA7QTg5dhc2qM2z5/oD0Dg9YEs5hg+Bpw==",
+      "dev": true,
+      "requires": {
+        "inspect-with-kind": "^1.0.4"
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "prepare-write": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/prepare-write/-/prepare-write-0.3.1.tgz",
+      "integrity": "sha512-p4NqFH9qi2Qjkh8OxdUSbF32+OVp6j/Vu/RQC/v0Yar5nWdmLQvDm+uEjy9Z8c+HgqC0tS0eZRLHnn+AWAk3Hg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "inspect-with-kind": "^1.0.2",
+        "is-dir": "^1.0.0",
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "requires": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "pulp": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/pulp/-/pulp-11.0.2.tgz",
+      "integrity": "sha512-qmAKx7daLNZOg2oqC/TiXJP+1SjN7M+DP2AfvCMUk/35oWQRLBN5ZEvUUJELAm0rudEgom4tzee0+36eR35p2w==",
+      "dev": true,
+      "requires": {
+        "browserify": "^13.1.0",
+        "browserify-incremental": "^3.0.1",
+        "concat-stream": "^1.4.6",
+        "glob": "^7.1.1",
+        "minimatch": "^3.0.3",
+        "node-static": "^0.7.9",
+        "read": "^1.0.7",
+        "string-stream": "0.0.7",
+        "temp": "^0.8.1",
+        "through": "^2.3.8",
+        "tree-kill": "^1.0.0",
+        "watchpack": "^1.0.1",
+        "which": "^1.2.1",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "pump": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "purescript": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.11.7.tgz",
+      "integrity": "sha512-Wvw/K7W2e2+dF6Jc926InVUtilF2eNuuOLTW6ij7ciTcTc1ynr20tHiopM1PuV/KzjZ5VwoOTVlh2IHiVikhJA==",
+      "dev": true,
+      "requires": {
+        "install-purescript-cli": "^0.2.0"
+      }
+    },
+    "purescript-psa": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/purescript-psa/-/purescript-psa-0.5.1.tgz",
+      "integrity": "sha1-LkNe7yK9L1froYLL/xIAIsoPJl8=",
+      "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "rate-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rate-map/-/rate-map-1.0.2.tgz",
+      "integrity": "sha512-fJ8x8KPEmMGT/LpoLqkbsbrLG1D26A0lzfhyNlVkO4ctvXiChulk0Y8iuZsJNd9RCK/wlqA/ihzU5vOwCR668g==",
+      "dev": true,
+      "requires": {
+        "append-type": "^1.0.1"
+      }
+    },
+    "react": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "requires": {
+        "create-react-class": "^15.6.0",
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
+      }
+    },
+    "react-dom": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+      "requires": {
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
+    "read-only-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "readdir-clean": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/readdir-clean/-/readdir-clean-0.4.0.tgz",
+      "integrity": "sha512-1HjVAFHcj/HQQNMNm0pIs2dTey0a4GO1cq1l6lIwYoSbnyC4IViVLyHF1M1n8dFYJOTCyrHgip42mTK+tk4/3Q==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "inspect-with-kind": "^1.0.2",
+        "junk": "^2.1.0"
+      }
+    },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "real-executable-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/real-executable-path/-/real-executable-path-2.0.2.tgz",
+      "integrity": "sha512-fRv44zvrzFeItoj/f/SNBqO/VWUHSZeqQ28oPOzd6weXaiRG6OVGu7UrHe6pY8JlXeoe/7gWYv6kOFHmHk4EFw==",
+      "dev": true,
+      "requires": {
+        "real-executable-path-callback": "^2.1.2"
+      }
+    },
+    "real-executable-path-callback": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/real-executable-path-callback/-/real-executable-path-callback-2.1.2.tgz",
+      "integrity": "sha512-dyOgKEhLKNg9tgFPs354X5fQpaAsUT+3dTO3JYoNLdPhMmRDjwwre6zHw58biFMVeFx9yxwI6MC7iMDfxSuMJA==",
+      "dev": true,
+      "requires": {
+        "inspect-with-kind": "^1.0.4",
+        "is-plain-obj": "^1.1.0",
+        "which": "^1.3.0"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "resolve-from-npm": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/resolve-from-npm/-/resolve-from-npm-2.0.4.tgz",
+      "integrity": "sha512-JrwN+SRILVjq/mdPNd6bhoOvYMBFf0CYqvfAgaDGB9dWjyr3XDAe40O2WcxToYWMmbQabM4FM6hHVLcSxBPKOQ==",
+      "dev": true,
+      "requires": {
+        "inspect-with-kind": "^1.0.3",
+        "npm-cli-dir": "^2.0.2",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "shasum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+      "dev": true,
+      "requires": {
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "dev": true,
+      "requires": {
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "dev": true
+    },
+    "size-rate": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/size-rate/-/size-rate-0.1.0.tgz",
+      "integrity": "sha512-Yinx2XAfbhJu+Pxz1TD3xFT6nPB54+wyRd4u82Kq+ZqzOtaODYS5/7QJtlOcRxJLUvNXMzJKGvJ/O1KyN/9+hQ==",
+      "dev": true,
+      "requires": {
+        "filesize": "^3.5.10",
+        "inspect-with-kind": "^1.0.2"
+      }
+    },
+    "slice-ansi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.1.0.tgz",
+      "integrity": "sha1-qITs8XjpjDauT2KSU3eKJNEu0Xs=",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "spawn-stack": {
+      "version": "0.3.1-0",
+      "resolved": "https://registry.npmjs.org/spawn-stack/-/spawn-stack-0.3.1-0.tgz",
+      "integrity": "sha512-z+vQvfaYODaQqJ9SBkYs+JW6DCYX4+2moyzjqW7+Hw9OoAqjjYiEFbOfFET153Xo365d23F3anjVkF7y1miWdQ==",
+      "dev": true,
+      "requires": {
+        "byline": "^5.0.0",
+        "execa": "^0.7.0",
+        "zen-observable": "^0.6.0"
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "stream-browserify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-http": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "stream-splicer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+      "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "string-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/string-stream/-/string-stream-0.0.7.tgz",
+      "integrity": "sha1-z83oJ5n6YvMDQpqqeTNu6INDMv4=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "syntax-error": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+      "dev": true,
+      "requires": {
+        "acorn-node": "^1.2.0"
+      }
+    },
+    "tar-fs": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
+      }
+    },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "dev": true,
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      }
+    },
+    "tar-to-file": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tar-to-file/-/tar-to-file-0.2.1.tgz",
+      "integrity": "sha512-ZrLV9wf3NHeFQ9o1ixRVvshDLu/L/jvSwMnKO0uC75tYTEkPUR7REuVLt3si4/wLwHnOhFtdOXDJSpZtmwoh3g==",
+      "dev": true,
+      "requires": {
+        "cancelable-pump": "^0.2.0",
+        "graceful-fs": "^4.1.11",
+        "inspect-with-kind": "^1.0.4",
+        "is-plain-obj": "^1.1.0",
+        "is-stream": "^1.1.0",
+        "tar-fs": "^1.16.0",
+        "tar-stream": "^1.5.5",
+        "zen-observable": "^0.6.1"
+      }
+    },
+    "temp": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "^1.0.0",
+        "rimraf": "~2.2.6"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
+        }
+      }
+    },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "tilde-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tilde-path/-/tilde-path-2.0.0.tgz",
+      "integrity": "sha512-3aDt7b/wBbxJjUTMiCW+uu7iqrB6F1DfxSL0qB4biSrP1+knIPveccs7thL34AkzPZ/0T7+oYXZDKiokMc1d6g==",
+      "dev": true
+    },
+    "timers-browserify": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+      "dev": true,
+      "requires": {
+        "process": "~0.11.0"
+      }
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "tree-kill": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
+      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+      "dev": true
+    },
+    "truncated-list": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/truncated-list/-/truncated-list-0.1.0.tgz",
+      "integrity": "sha512-8ZkhXPh8EGrD9tLqnVwjB2BRMSLQCRR8YyXzQgKzWi7t3Z3f2UerOA3SHCFOoVjck6JhMwtVJXZKtEb2lJODWg==",
+      "dev": true,
+      "requires": {
+        "inspect-with-kind": "^1.0.2"
+      }
+    },
+    "tty-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true
+    },
+    "tty-truncate": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tty-truncate/-/tty-truncate-0.3.1.tgz",
+      "integrity": "sha512-4ehw5Wudz1oi7YFP7jhDOggwE6TLzz6qvwEczMxZho7iePs1MEcl+LfXn+pauu7b9F87DK0RlABxPzXGbqeyFw==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0",
+        "inspect-with-kind": "^1.0.2",
+        "slice-ansi": "^0.1.0",
+        "string-width": "^2.1.0"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.19",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
+      "dev": true
+    },
+    "umd": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
+      "dev": true
+    },
+    "undeclared-identifiers": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.2.tgz",
+      "integrity": "sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==",
+      "dev": true,
+      "requires": {
+        "acorn-node": "^1.3.0",
+        "get-assigned-identifiers": "^1.2.0",
+        "simple-concat": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "vertical-meter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/vertical-meter/-/vertical-meter-0.2.0.tgz",
+      "integrity": "sha512-T6xst4Izns8EXKspreATKlKAUXbAjRYH2ocuNlsEiiMXgvTuxbB8K5KgEie3Gmuc59FMHiKF0NWoCuTEWpGAng==",
+      "dev": true,
+      "requires": {
+        "rate-map": "^1.0.1"
+      }
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "watchpack": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "win-user-installed-npm-cli-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/win-user-installed-npm-cli-path/-/win-user-installed-npm-cli-path-2.0.4.tgz",
+      "integrity": "sha512-i+fSInL3Li47P9gGcJabtgvl2+hLmZwMsh4664WWuI1F/pQPtv4XerrOyg8poxvDv4o/QwB60f20MKtIX/CCxQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+      "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "zen-observable": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.6.1.tgz",
+      "integrity": "sha512-DKjFTL7siVLIUMZOFZ0alqMEdTsXPUxoCZzrvB2tdWEVN/6606Qh1nCfSTCAOZMrtcPzzFI3BXmwBKLAew52NA==",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,11 +147,6 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -879,11 +874,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -925,16 +915,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
       }
     },
     "cross-spawn": {
@@ -1210,14 +1190,6 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -1395,20 +1367,6 @@
             "kind-of": "^6.0.2"
           }
         }
-      }
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
       }
     },
     "feint": {
@@ -2197,14 +2155,6 @@
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
       "dev": true
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
@@ -2469,7 +2419,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -2494,15 +2445,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2921,15 +2863,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node-static": {
       "version": "0.7.11",
       "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.11.tgz",
@@ -3217,21 +3150,14 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "pseudomap": {
@@ -3350,27 +3276,31 @@
       }
     },
     "react": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.2.tgz",
+      "integrity": "sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==",
       "requires": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.2"
       }
     },
     "react-dom": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.2.tgz",
+      "integrity": "sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==",
       "requires": {
-        "fbjs": "^0.8.9",
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.2"
       }
+    },
+    "react-is": {
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.2.tgz",
+      "integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q=="
     },
     "read": {
       "version": "1.0.7",
@@ -3566,11 +3496,6 @@
         "ret": "~0.1.10"
       }
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
@@ -3581,6 +3506,15 @@
         "graceful-fs": "^4.1.3",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.2"
+      }
+    },
+    "scheduler": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.2.tgz",
+      "integrity": "sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "semver": {
@@ -3611,11 +3545,6 @@
           }
         }
       }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -4267,11 +4196,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "ua-parser-js": {
-      "version": "0.7.19",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
-    },
     "umd": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
@@ -4444,11 +4368,6 @@
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "which": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,9 @@
       }
     },
     "app-cache-dir": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/app-cache-dir/-/app-cache-dir-0.2.1.tgz",
-      "integrity": "sha512-UdSjcARK1TxWteoGRl66MO5VRwc3uOe+rt3HmH95c+PUasN82PuDLBtmpNQ8+uoqFoUs8KJOtNv5PXgkIqEdCw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/app-cache-dir/-/app-cache-dir-0.3.1.tgz",
+      "integrity": "sha512-zJ/Gj1wEQ7Z9yuLID6XhAaSbWGkGVEwMkqcrv5/Jv0GCT19UpDKkyybq84SOWBi+WzT7Y3mihYXGtMnK7Z3DMQ==",
       "dev": true,
       "requires": {
         "inspect-with-kind": "^1.0.2"
@@ -193,6 +193,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async": {
@@ -607,6 +613,12 @@
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
       "dev": true
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -626,13 +638,13 @@
       "dev": true
     },
     "build-purescript": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/build-purescript/-/build-purescript-0.1.1.tgz",
-      "integrity": "sha512-f6zuH9SV9m105gFWL0OHslwPuX7OdfEpFE6sSfq7Ai7bZbe35O+sN7hovBwO3uCvU2FMMrKoHUtO8ukEfgUq9Q==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/build-purescript/-/build-purescript-0.2.3.tgz",
+      "integrity": "sha512-oIBeOxbEHG8don4jqxCMhZxoXCqk21jIqN+a9U/8jiiwYOAS6KcssxcTklhE+LzEIsBx/hh8cObQ5Lupos/mVw==",
       "dev": true,
       "requires": {
-        "download-purescript-source": "^0.3.2",
-        "feint": "^1.0.1",
+        "download-purescript-source": "^0.4.0",
+        "feint": "^1.0.2",
         "graceful-fs": "^4.1.11",
         "inspect-with-kind": "^1.0.4",
         "is-plain-obj": "^1.1.0",
@@ -640,9 +652,8 @@
         "mkdirp": "^0.5.1",
         "once": "^1.4.0",
         "rimraf": "^2.6.2",
-        "spawn-stack": "0.3.1-0 ",
-        "uid2": "^0.0.3",
-        "zen-observable": "^0.6.0"
+        "spawn-stack": "^0.5.0",
+        "zen-observable": "^0.6.1"
       }
     },
     "builtin-status-codes": {
@@ -701,9 +712,9 @@
       }
     },
     "chokidar": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.0.tgz",
-      "integrity": "sha512-5t6G2SH8eO6lCvYOoUpaRnF5Qfd//gd7qJAkwRUw9qlGVkiQ13uwQngqbWWaurOsaAm9+kUGbITADxt6H0XFNQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.1.tgz",
+      "integrity": "sha512-gfw3p2oQV2wEt+8VuMlNsPjCxDxvvgnm/kz+uATu805mWVF8IJN7uz9DN7iBz+RMJISmiVbCOBFs9qBGMjtPfQ==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -760,9 +771,9 @@
       }
     },
     "clean-stack": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
+      "integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==",
       "dev": true
     },
     "cli-cursor": {
@@ -927,12 +938,14 @@
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
@@ -1076,9 +1089,9 @@
       }
     },
     "dl-tar": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/dl-tar/-/dl-tar-0.5.3.tgz",
-      "integrity": "sha512-4e0DMD0uVz8z1nC44MvJRDyAI9FS6Q1ROzECdvB+nB3SrSOjbPJ2IPLSNhyqlz9QoQg9fqAitsFbwBLyNXCrCw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dl-tar/-/dl-tar-0.6.0.tgz",
+      "integrity": "sha512-bh6sKubl/RzCNC6v6PEim13GDA0D0OEq8j1yqORFQrVnH8C1aaP2xb4BSRP8VxFPKYVvAi4zzDEBMr72z2M9Wg==",
       "dev": true,
       "requires": {
         "cancelable-pump": "^0.2.0",
@@ -1089,18 +1102,18 @@
         "load-request-from-cwd-or-npm": "^2.0.1",
         "tar-fs": "^1.16.0",
         "tar-stream": "^1.5.5",
-        "zen-observable": "^0.6.0"
+        "zen-observable": "^0.6.1"
       }
     },
     "dl-tgz": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/dl-tgz/-/dl-tgz-0.5.1.tgz",
-      "integrity": "sha512-EHTJROgl6wtka3fNkKJwuz2Q+id0sCIJ3ZXF7GXRbNJAcgyrkEg9dNzmvte7TnScvzDDOPD80q8n+GyjWrHd+A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dl-tgz/-/dl-tgz-0.6.0.tgz",
+      "integrity": "sha512-pkf0P6EwWfVmpbFTvgfrWOh9JvrCwW/bnx2i+M9ffKfKCP20B/3ZHRL/jGXL8nuZ+TQcI/rsasx1fzjf+expmQ==",
       "dev": true,
       "requires": {
-        "dl-tar": "^0.5.2",
+        "dl-tar": "^0.6.0",
         "is-plain-obj": "^1.1.0",
-        "zen-observable": "^0.6.0"
+        "zen-observable": "^0.6.1"
       }
     },
     "domain-browser": {
@@ -1110,44 +1123,58 @@
       "dev": true
     },
     "download-or-build-purescript": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/download-or-build-purescript/-/download-or-build-purescript-0.0.7.tgz",
-      "integrity": "sha512-Zgerb2bptzdKGY3shw9PFE/riK7L8kK6/rMmrTWui4+nG64pH4eHHu55qPSeGt7/81Feur5i/hRsVMyo5yjh8g==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/download-or-build-purescript/-/download-or-build-purescript-0.0.9.tgz",
+      "integrity": "sha512-1SOq5zLZd2Nh1bmyQUhMlmZoUxuUMYYTHcyU8kR2Y9nRRiuogEWQcD2+SiJfEl5S6Ap+S4x2hVNP3bbQp0/80g==",
       "dev": true,
       "requires": {
-        "build-purescript": "^0.1.0",
-        "download-purescript": "^0.3.0",
-        "execa": "^0.7.0",
-        "feint": "1.0.1",
+        "build-purescript": "^0.2.0",
+        "download-purescript": "0.5.0-0",
+        "execa": "^0.10.0",
+        "feint": "^1.0.2",
         "graceful-fs": "^4.1.11",
-        "inspect-with-kind": "^1.0.3",
+        "inspect-with-kind": "^1.0.4",
         "is-plain-obj": "^1.1.0",
         "once": "^1.4.0",
-        "prepare-write": "^0.3.0",
-        "spawn-stack": "0.3.1-0",
+        "prepare-write": "^0.3.1",
+        "spawn-stack": "^0.5.0",
         "which": "^1.3.0",
         "zen-observable": "^0.6.0"
+      },
+      "dependencies": {
+        "prepare-write": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/prepare-write/-/prepare-write-0.3.1.tgz",
+          "integrity": "sha512-p4NqFH9qi2Qjkh8OxdUSbF32+OVp6j/Vu/RQC/v0Yar5nWdmLQvDm+uEjy9Z8c+HgqC0tS0eZRLHnn+AWAk3Hg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "inspect-with-kind": "^1.0.2",
+            "is-dir": "^1.0.0",
+            "mkdirp": "^0.5.1"
+          }
+        }
       }
     },
     "download-purescript": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/download-purescript/-/download-purescript-0.3.3.tgz",
-      "integrity": "sha512-miZR+nufWL1dbJd6sfFlI7WA0FguFNo8o11tEW1qnsGLD+ClhfF8jaUDyPbcrbD5CSgUBfB6a5JTumGFts+rLg==",
+      "version": "0.5.0-0",
+      "resolved": "https://registry.npmjs.org/download-purescript/-/download-purescript-0.5.0-0.tgz",
+      "integrity": "sha512-oBjNPPBBB/zcsIvn9VUgL+YnT9E3dSszwISKmPxU4ehIkAisysrII8pvQAoQRxSikppJhmajo/VYEpa5LD0whQ==",
       "dev": true,
       "requires": {
-        "dl-tgz": "^0.5.1",
+        "dl-tgz": "^0.6.0",
         "inspect-with-kind": "^1.0.4",
         "is-plain-obj": "^1.1.0",
         "zen-observable": "^0.6.1"
       }
     },
     "download-purescript-source": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/download-purescript-source/-/download-purescript-source-0.3.2.tgz",
-      "integrity": "sha512-Vt9gH6IOrrRnsSbjIrMWtKt86VYoYYyQQMF7mvweLDop99QJPolYcpsURyFxbT2GoLjwqI4L6l47dn5hzu/t4A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/download-purescript-source/-/download-purescript-source-0.4.0.tgz",
+      "integrity": "sha512-Y+5VqajGu9uv63XbY7R27UZGplqxQkyYMg52nSBHQMOyML/2TIm4HmP3trTSM2lxFR4yCeKGQgPas35OERCFWg==",
       "dev": true,
       "requires": {
-        "dl-tgz": "^0.5.1",
+        "dl-tgz": "^0.6.0",
         "inspect-with-kind": "^1.0.4",
         "is-plain-obj": "^1.1.0",
         "zen-observable": "^0.6.1"
@@ -1177,6 +1204,12 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
@@ -1193,6 +1226,12 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1217,12 +1256,12 @@
       }
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
+        "cross-spawn": "^6.0.0",
         "get-stream": "^3.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
@@ -1373,28 +1412,49 @@
       }
     },
     "feint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/feint/-/feint-1.0.1.tgz",
-      "integrity": "sha1-FsZCrfN+vzSHjy64MY96X71si5w=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/feint/-/feint-1.0.2.tgz",
+      "integrity": "sha512-PC77rn63FAMGcmHEkuGh4AdofqI6/c/YGjyvLo60mGLcCOHUUzCnKFzoij062piVgBblkl/KlN1vHGVJsK88cg==",
       "dev": true,
       "requires": {
-        "append-type": "^1.0.0"
+        "append-type": "^1.0.1"
       }
     },
     "file-to-tar": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/file-to-tar/-/file-to-tar-0.2.3.tgz",
-      "integrity": "sha512-nFcPj8HwSRdqxLX4Fja7oCzQOSQSrS1iCnJZDMn+i2MvW+wXh4uoUPLE9NlUUdMAsmXoG8oTFalXBf6V66g6hA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/file-to-tar/-/file-to-tar-0.3.1.tgz",
+      "integrity": "sha512-bFYkxQR2weH7Bgdj6Dxuo+0rRZagcqY0uuu2CcXUdrOp8TFfkGYEdHy3uSqLiwhkXCcFFDk0584bdIyyEvJKBA==",
       "dev": true,
       "requires": {
-        "cancelable-pump": "^0.2.0",
+        "cancelable-pump": "^0.4.0",
         "graceful-fs": "^4.1.11",
         "inspect-with-kind": "^1.0.4",
         "is-plain-obj": "^1.1.0",
         "is-stream": "^1.1.0",
         "mkdirp": "^0.5.1",
-        "tar-fs": "^1.16.0",
+        "tar-fs": "^1.16.2",
         "zen-observable": "^0.6.1"
+      },
+      "dependencies": {
+        "cancelable-pump": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cancelable-pump/-/cancelable-pump-0.4.0.tgz",
+          "integrity": "sha512-7Yvp8ADC9exD0Kdq/Q35UD5wOiuXTTLp159gFHC+uMQvjRMllrsM6EUKnozmIe43yesLBiH/ni0KD69k07yzZQ==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "filesize": {
@@ -2210,50 +2270,50 @@
       }
     },
     "install-purescript": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/install-purescript/-/install-purescript-0.2.1.tgz",
-      "integrity": "sha512-ehbjJr5GnOOcyUfAXYiHD471NV+QTNuIY8piDhg4YcgBFFqf05QQbAOd+oyoRdJtLGsuTbJdnAEdDh3fvnDb9g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/install-purescript/-/install-purescript-0.4.0.tgz",
+      "integrity": "sha512-hXfy12CP/aSCxEhx75kA2jTsbUrkQYFwbolNIrFcFVaiSYc3GpEcAsLqSuijzMCtfxAq+2S6Uw5o6QrVVNVpwQ==",
       "dev": true,
       "requires": {
-        "app-cache-dir": "^0.2.1",
+        "app-cache-dir": "^0.3.0",
         "arch": "^2.1.0",
-        "download-or-build-purescript": "^0.0.7",
-        "execa": "^0.7.0",
-        "feint": "1.0.1",
-        "file-to-tar": "^0.2.2",
+        "download-or-build-purescript": "^0.0.9",
+        "execa": "^0.10.0",
+        "feint": "1.0.2",
+        "file-to-tar": "^0.3.1",
         "graceful-fs": "^4.1.11",
         "inspect-with-kind": "^1.0.4",
         "is-plain-obj": "^1.1.0",
         "once": "^1.4.0",
-        "prepare-write": "^0.3.1",
-        "readdir-clean": "^0.4.0",
+        "prepare-write": "^1.0.0",
+        "readdir-clean": "^1.0.0",
         "rimraf": "^2.6.2",
-        "tar-to-file": "^0.2.0",
+        "tar-to-file": "^0.4.0",
         "tilde-path": "^2.0.0",
-        "truncated-list": "^0.1.0",
-        "zen-observable": "^0.6.0"
+        "truncated-list": "^1.0.1",
+        "zen-observable": "^0.6.1"
       }
     },
     "install-purescript-cli": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/install-purescript-cli/-/install-purescript-cli-0.2.1.tgz",
-      "integrity": "sha512-4QbrfCeYAwfCRbmx+5UxFl6IYRGKPYKy+UxnZDkYvE0LM7uput/RfEUym5GzCwG8ra6DbtgXfEaQVl3tMstfJw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/install-purescript-cli/-/install-purescript-cli-0.3.0.tgz",
+      "integrity": "sha512-fxxJ2nnKfDHli530XVz7w5bd5I7UKODtVjMLJuvpOHPSqPfHgOPqHat2vjPTqaW5B4sHt3NYGopvt/fYPfwl2A==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
-        "install-purescript": "^0.2.0",
+        "install-purescript": "^0.4.0",
         "log-symbols": "^2.2.0",
         "log-update": "^2.3.0",
         "minimist": "^1.2.0",
         "ms": "^2.1.1",
-        "neat-frame": "^0.2.0",
-        "neat-stack": "^0.1.2",
+        "neat-frame": "^1.0.1",
+        "neat-stack": "^1.0.0",
         "once": "^1.4.0",
-        "platform-name": "^0.6.1",
+        "platform-name": "^1.0.0",
         "size-rate": "^0.1.0",
         "tilde-path": "^2.0.0",
-        "tty-truncate": "^0.3.1",
-        "vertical-meter": "^0.2.0"
+        "tty-truncate": "^1.0.0",
+        "vertical-meter": "^1.0.0"
       },
       "dependencies": {
         "ms": {
@@ -2758,6 +2818,24 @@
         }
       }
     },
+    "mold-source-map": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mold-source-map/-/mold-source-map-0.4.0.tgz",
+      "integrity": "sha1-z2fgsxxHq5uttcnCVlGGISe7gxc=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "^1.1.0",
+        "through": "~2.2.7"
+      },
+      "dependencies": {
+        "through": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+          "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
+          "dev": true
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2797,31 +2875,50 @@
       }
     },
     "neat-frame": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/neat-frame/-/neat-frame-0.2.0.tgz",
-      "integrity": "sha512-7GOJQFq7MUJNMsYFfJ4Uk7Mi0MtIpX8xxtoP+zRuOoazTmHckvDCcGa6oRR6YwvmG+TIQSrkmIgolxAXM+2k8Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/neat-frame/-/neat-frame-1.0.2.tgz",
+      "integrity": "sha512-V1aFRKYLeHt8j+/Zcth3wRlQVd5jiWlXyT1McmW6dJvE08wxZXUp38pwFhoIMSr4f3N2UEcJvR1z0VKrSCwYsQ==",
       "dev": true,
       "requires": {
-        "inspect-with-kind": "^1.0.2",
+        "inspect-with-kind": "^1.0.5",
         "string-width": "^2.1.1",
         "term-size": "^1.2.0",
-        "wrap-ansi": "^3.0.1"
+        "wrap-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "wrap-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+          "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          }
+        }
       }
     },
     "neat-stack": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/neat-stack/-/neat-stack-0.1.2.tgz",
-      "integrity": "sha512-IM2Xfjma9Czp1FkFZBQVWm36156RFcpm7s4oWCmPqsD44RdgHSA3YtJykkQIpTHGFkVVWEpG811HUUB5e/kkLg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/neat-stack/-/neat-stack-1.0.1.tgz",
+      "integrity": "sha512-nl0eft4etsbFowZVP+1lNqZsNKb2SIC+PnAr/ODBln6RNVaJh0YYu8P3j8Iuh4XeIAgyWn3xCSizbTobRjocIA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
-        "clean-stack": "^1.3.0"
+        "chalk": "^2.4.1",
+        "clean-stack": "^2.0.0"
       }
     },
     "neo-async": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "node-fetch": {
@@ -3084,9 +3181,9 @@
       }
     },
     "platform-name": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/platform-name/-/platform-name-0.6.1.tgz",
-      "integrity": "sha512-2ZCglHx00s/cQ6CK27tB6gh6WYO6Rm1caXihLUg0+wqLslUvWKBoOSA7QTg5dhc2qM2z5/oD0Dg9YEs5hg+Bpw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/platform-name/-/platform-name-1.0.0.tgz",
+      "integrity": "sha512-ZRbqJ30uRRKGKW2O1XnG/Ls1K/aBGlnyjq1Z0BbjqDPTNN+XZKFaugCsCm3/mq6XGR5DZNVdV75afpQEvNNY3Q==",
       "dev": true,
       "requires": {
         "inspect-with-kind": "^1.0.4"
@@ -3099,14 +3196,12 @@
       "dev": true
     },
     "prepare-write": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/prepare-write/-/prepare-write-0.3.1.tgz",
-      "integrity": "sha512-p4NqFH9qi2Qjkh8OxdUSbF32+OVp6j/Vu/RQC/v0Yar5nWdmLQvDm+uEjy9Z8c+HgqC0tS0eZRLHnn+AWAk3Hg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/prepare-write/-/prepare-write-1.0.2.tgz",
+      "integrity": "sha512-3g6wGYFExqBDGw1P9oYrKbeSymmYcYIxiOlWzyIV4nOqrf5jiiFE8N7eU53a8UBtW8gsSwk2YQBz67VeDEafQA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "inspect-with-kind": "^1.0.2",
-        "is-dir": "^1.0.0",
+        "inspect-with-kind": "^1.0.5",
         "mkdirp": "^0.5.1"
       }
     },
@@ -3160,9 +3255,9 @@
       }
     },
     "pulp": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/pulp/-/pulp-11.0.2.tgz",
-      "integrity": "sha512-qmAKx7daLNZOg2oqC/TiXJP+1SjN7M+DP2AfvCMUk/35oWQRLBN5ZEvUUJELAm0rudEgom4tzee0+36eR35p2w==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/pulp/-/pulp-12.3.1.tgz",
+      "integrity": "sha512-UVkXppOVShd8GRe+dGWGihGhYgPnwGv2GszGAUUKlWg61qB5yFBlcNHJywyE0yZhuA5HWTt5JCmnfVYqTL0hqQ==",
       "dev": true,
       "requires": {
         "browserify": "^13.1.0",
@@ -3170,8 +3265,10 @@
         "concat-stream": "^1.4.6",
         "glob": "^7.1.1",
         "minimatch": "^3.0.3",
+        "mold-source-map": "^0.4.0",
         "node-static": "^0.7.9",
         "read": "^1.0.7",
+        "sorcery": "^0.10.0",
         "string-stream": "0.0.7",
         "temp": "^0.8.1",
         "through": "^2.3.8",
@@ -3198,18 +3295,18 @@
       "dev": true
     },
     "purescript": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.11.7.tgz",
-      "integrity": "sha512-Wvw/K7W2e2+dF6Jc926InVUtilF2eNuuOLTW6ij7ciTcTc1ynr20tHiopM1PuV/KzjZ5VwoOTVlh2IHiVikhJA==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.12.2.tgz",
+      "integrity": "sha512-RYUJcFKStFM4PihA9rc5Bhc2KGBxG7pjaF1/+twHAEKgkIb0V2ExcLswgA52scnbOSZ5xgTk4CJvUzxZDMa+kQ==",
       "dev": true,
       "requires": {
-        "install-purescript-cli": "^0.2.0"
+        "install-purescript-cli": "^0.4.0 || ^0.3.0"
       }
     },
     "purescript-psa": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/purescript-psa/-/purescript-psa-0.5.1.tgz",
-      "integrity": "sha1-LkNe7yK9L1froYLL/xIAIsoPJl8=",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/purescript-psa/-/purescript-psa-0.7.3.tgz",
+      "integrity": "sha512-qcnhruybTHVunhJqAuurOEWnz1BOOc/7mpcnyH5yxm5caYCejxq8GOE4ZNWbiPMeTlcG79qUPIOz7gx5OVmk2Q==",
       "dev": true
     },
     "querystring": {
@@ -3320,13 +3417,11 @@
       }
     },
     "readdir-clean": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/readdir-clean/-/readdir-clean-0.4.0.tgz",
-      "integrity": "sha512-1HjVAFHcj/HQQNMNm0pIs2dTey0a4GO1cq1l6lIwYoSbnyC4IViVLyHF1M1n8dFYJOTCyrHgip42mTK+tk4/3Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readdir-clean/-/readdir-clean-1.0.1.tgz",
+      "integrity": "sha512-qeAvS+0//+S20//w1qozhLO1xPNNWWei5qzNPvYgYuKUmaHky0n3bweB/vBIi/xxjcUCOfL0r5lOPSeNazZ6Yg==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "inspect-with-kind": "^1.0.2",
         "junk": "^2.1.0"
       }
     },
@@ -3476,6 +3571,24 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sander": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      }
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
@@ -3574,10 +3687,15 @@
       }
     },
     "slice-ansi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.1.0.tgz",
-      "integrity": "sha1-qITs8XjpjDauT2KSU3eKJNEu0Xs=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -3686,6 +3804,18 @@
         }
       }
     },
+    "sorcery": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+      "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^0.2.5",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0",
+        "sourcemap-codec": "^1.3.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -3711,15 +3841,22 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+      "dev": true
+    },
     "spawn-stack": {
-      "version": "0.3.1-0",
-      "resolved": "https://registry.npmjs.org/spawn-stack/-/spawn-stack-0.3.1-0.tgz",
-      "integrity": "sha512-z+vQvfaYODaQqJ9SBkYs+JW6DCYX4+2moyzjqW7+Hw9OoAqjjYiEFbOfFET153Xo365d23F3anjVkF7y1miWdQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/spawn-stack/-/spawn-stack-0.5.0.tgz",
+      "integrity": "sha512-suwvBV2WNTOYe/TQBoAFrGbdRvo5t/pWYq/vNw24wbSmIJXr/eaadsF+92VyPm2dBYsYwBnsTLhQFCo3EdCA+Q==",
       "dev": true,
       "requires": {
         "byline": "^5.0.0",
-        "execa": "^0.7.0",
-        "zen-observable": "^0.6.0"
+        "execa": "^0.10.0",
+        "inspect-with-kind": "^1.0.4",
+        "zen-observable": "^0.6.1"
       }
     },
     "split-string": {
@@ -3887,19 +4024,40 @@
       }
     },
     "tar-to-file": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tar-to-file/-/tar-to-file-0.2.1.tgz",
-      "integrity": "sha512-ZrLV9wf3NHeFQ9o1ixRVvshDLu/L/jvSwMnKO0uC75tYTEkPUR7REuVLt3si4/wLwHnOhFtdOXDJSpZtmwoh3g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/tar-to-file/-/tar-to-file-0.4.0.tgz",
+      "integrity": "sha512-DFRBSotqmgeMrU/H7z0VIMPv8taOheRUlAhi6Q+r5Xso9xoa5vez/Z3uvASSzuT1dwe2orAdENT7NXlAh1zwvA==",
       "dev": true,
       "requires": {
-        "cancelable-pump": "^0.2.0",
+        "cancelable-pump": "^0.4.0",
         "graceful-fs": "^4.1.11",
         "inspect-with-kind": "^1.0.4",
         "is-plain-obj": "^1.1.0",
         "is-stream": "^1.1.0",
-        "tar-fs": "^1.16.0",
-        "tar-stream": "^1.5.5",
+        "tar-fs": "^1.16.2",
+        "tar-stream": "^1.6.1",
         "zen-observable": "^0.6.1"
+      },
+      "dependencies": {
+        "cancelable-pump": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cancelable-pump/-/cancelable-pump-0.4.0.tgz",
+          "integrity": "sha512-7Yvp8ADC9exD0Kdq/Q35UD5wOiuXTTLp159gFHC+uMQvjRMllrsM6EUKnozmIe43yesLBiH/ni0KD69k07yzZQ==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "temp": {
@@ -3927,6 +4085,34 @@
       "dev": true,
       "requires": {
         "execa": "^0.7.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
       }
     },
     "through": {
@@ -4021,12 +4207,12 @@
       "dev": true
     },
     "truncated-list": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/truncated-list/-/truncated-list-0.1.0.tgz",
-      "integrity": "sha512-8ZkhXPh8EGrD9tLqnVwjB2BRMSLQCRR8YyXzQgKzWi7t3Z3f2UerOA3SHCFOoVjck6JhMwtVJXZKtEb2lJODWg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/truncated-list/-/truncated-list-1.0.1.tgz",
+      "integrity": "sha512-aNcDZ1PfxAtUXXLEmy+m1D465lFv0VgWltGlTWuJuhPh+FGeOiHV9S2DYOD8IEgZU8yOInZBRHVcAts+xIYzew==",
       "dev": true,
       "requires": {
-        "inspect-with-kind": "^1.0.2"
+        "inspect-with-kind": "^1.0.4"
       }
     },
     "tty-browserify": {
@@ -4036,15 +4222,43 @@
       "dev": true
     },
     "tty-truncate": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/tty-truncate/-/tty-truncate-0.3.1.tgz",
-      "integrity": "sha512-4ehw5Wudz1oi7YFP7jhDOggwE6TLzz6qvwEczMxZho7iePs1MEcl+LfXn+pauu7b9F87DK0RlABxPzXGbqeyFw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tty-truncate/-/tty-truncate-1.0.3.tgz",
+      "integrity": "sha512-zQH6DMwCBUHuS/3jIgvgZq14TaxujXZjifyOsamBmlVsLRzkm+vFoSW4oJCoD1PE3i6qY+bTjnsj3yqZn8l2JQ==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0",
-        "inspect-with-kind": "^1.0.2",
-        "slice-ansi": "^0.1.0",
-        "string-width": "^2.1.0"
+        "ansi-regex": "^4.0.0",
+        "inspect-with-kind": "^1.0.5",
+        "slice-ansi": "^2.0.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
+          "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
       }
     },
     "typedarray": {
@@ -4057,12 +4271,6 @@
       "version": "0.7.19",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
       "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
-    },
-    "uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-      "dev": true
     },
     "umd": {
       "version": "3.0.3",
@@ -4209,9 +4417,9 @@
       "dev": true
     },
     "vertical-meter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/vertical-meter/-/vertical-meter-0.2.0.tgz",
-      "integrity": "sha512-T6xst4Izns8EXKspreATKlKAUXbAjRYH2ocuNlsEiiMXgvTuxbB8K5KgEie3Gmuc59FMHiKF0NWoCuTEWpGAng==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vertical-meter/-/vertical-meter-1.0.0.tgz",
+      "integrity": "sha512-xvtone0DHRBrWSBVF2p3+/KSz/mzHvDZ7+HYB3g68hBpqIC3tIF8J1maf5osHPKHB/45iq2B+T4ju/mfxArd/Q==",
       "dev": true,
       "requires": {
         "rate-map": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "react-dom": "^15.6.1"
   },
   "devDependencies": {
-    "pulp": "^11.0.0",
-    "purescript-psa": "^0.5.0",
-    "purescript": "^0.11.1",
-    "rimraf": "^2.5.4"
+    "pulp": "^12.3.1",
+    "purescript-psa": "^0.7.3",
+    "purescript": "^0.12.0",
+    "rimraf": "^2.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "example": "pulp test -r cat > html/index.js"
   },
   "dependencies": {
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react": "^16.8.2",
+    "react-dom": "^16.8.2"
   },
   "devDependencies": {
     "pulp": "^12.3.1",

--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -15,6 +15,7 @@ module Thermite
   , defaultPerformAction
   , Dispatch
   , Render
+  , WithChildren
   , defaultRender
   , writeState
   , modifyState
@@ -94,6 +95,10 @@ type Render state props action
   -> state
   -> Array React.ReactElement
   -> Array React.ReactElement
+
+-- | Convenience type when specifying the type of a `Spec`.
+type WithChildren props = { children :: Children | props }
+
 
 -- | A default `Render` implementation which renders nothing.
 -- |

--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -262,11 +262,11 @@ createReactSpec' wrap (Spec spec) initState =
       launchAff (tailRecM step cotransformer)
 
     render :: React.ReactThis { children :: Children | props } { | state } -> React.Render
-    render this = pure (wrap [text "foo"])
-      -- map wrap $ do
-      -- props <- React.getProps this
-      -- state <- React.getState this
-      -- pure $ spec.render (dispatcher this) props state (React.childrenToArray props.children)
+    render this = -- pure (wrap [text "foo"])
+      map wrap $ do
+        props <- React.getProps this
+        state <- React.getState this
+        pure $ spec.render (dispatcher this) props state (React.childrenToArray props.children)
 
 -- | A default implementation of `main` which renders a component to the
 -- | document body.

--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -54,7 +54,6 @@ import Data.Foldable (for_, traverse_)
 import Data.Lens (Prism', Lens', matching, view, review, preview, lens, over)
 import Data.List (List(..), (!!), modifyAt)
 import Data.Maybe (Maybe(Just), fromMaybe)
-import Data.Monoid (class Monoid)
 import Data.Tuple (Tuple(..))
 import React (unsafeCreateElement, Children)
 import React as React

--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -57,7 +57,7 @@ import Data.Maybe (Maybe(Just), fromMaybe)
 import Data.Tuple (Tuple(..))
 import React (unsafeCreateElement, Children)
 import React as React
-import React.DOM (div')
+import React.DOM (div', text)
 import ReactDOM (render)
 
 -- | A type synonym for an action handler, which takes an action, the current props
@@ -246,7 +246,7 @@ createReactSpec' wrap (Spec spec) initState =
                     go cb = do
                       let cont :: Effect Unit
                           cont = cb (Right newState)
-                      void $ React.writeStateWithCallback this newState cont
+                      void (React.writeStateWithCallback this newState cont)
                       pure nonCanceler
 
                 _ <- makeAff go
@@ -262,10 +262,11 @@ createReactSpec' wrap (Spec spec) initState =
       launchAff (tailRecM step cotransformer)
 
     render :: React.ReactThis { children :: Children | props } { | state } -> React.Render
-    render this = map wrap $ do
-      props <- React.getProps this
-      state <- React.getState this
-      pure $ spec.render (dispatcher this) props state (React.childrenToArray props.children)
+    render this = pure (wrap [text "foo"])
+      -- map wrap $ do
+      -- props <- React.getProps this
+      -- state <- React.getState this
+      -- pure $ spec.render (dispatcher this) props state (React.childrenToArray props.children)
 
 -- | A default implementation of `main` which renders a component to the
 -- | document body.

--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -37,7 +37,7 @@ module Thermite
   ) where
 
 import Prelude
-import Effect.Aff (Aff, launchAff, makeAff, nonCanceler, Fiber)
+import Effect.Aff (Aff, launchAff, makeAff, nonCanceler)
 import Effect (Effect)
 import Control.Monad.Free.Trans (resume)
 import Control.Monad.Rec.Class (Step(..), forever, tailRecM)
@@ -84,7 +84,7 @@ modifyState :: forall state. (state -> state) -> CoTransformer (Maybe state) (st
 modifyState = cotransform
 
 -- | A type synonym for a `dispatch`able function of action types.
-type Dispatch action = action -> Effect (Fiber Unit)
+type Dispatch action = action -> Effect Unit
 
 -- | A rendering function, which takes an action handler function, the current state and
 -- | props, an array of child nodes and returns a HTML document.
@@ -232,7 +232,7 @@ createReactConstructor (Spec spec) initState =
 
       -- Step the coroutine manually, since none of the existing coroutine
       -- functions do quite what we want here.
-      launchAff (tailRecM step cotransformer)
+      void $ launchAff $ tailRecM step cotransformer
 
     render :: React.ReactThis { children :: Children | props } { | state } -> React.Render
     render this = do

--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -211,7 +211,7 @@ createReactSpec
   :: forall eff state props action
    . Spec eff state props action
   -> state
-  -> { spec :: React.ReactSpec props state eff
+  -> { spec :: React.ReactSpec props state React.ReactElement eff
      , dispatcher :: React.ReactThis props state -> action -> EventHandler
      }
 createReactSpec = createReactSpec' div'
@@ -228,7 +228,7 @@ createReactSpec'
    . (Array React.ReactElement -> React.ReactElement)
   -> Spec eff state props action
   -> state
-  -> { spec :: React.ReactSpec props state eff
+  -> { spec :: React.ReactSpec props state React.ReactElement eff
      , dispatcher :: React.ReactThis props state -> action -> EventHandler
      }
 createReactSpec' wrap (Spec spec) =
@@ -264,7 +264,7 @@ createReactSpec' wrap (Spec spec) =
       -- functions do quite what we want here.
       unsafeCoerceEff (launchAff (tailRecM step cotransformer))
 
-    render :: React.Render props state eff
+    render :: React.Render props state React.ReactElement eff
     render this = map wrap $
       spec.render (dispatcher this)
         <$> React.getProps this

--- a/src/Thermite.purs
+++ b/src/Thermite.purs
@@ -203,7 +203,7 @@ createReactSpec
   :: forall state props action
    . Spec { | state } { children :: Children | props } action
   -> { | state }
-  -> { constructor :: React.ReactClassConstructor { children :: Children | props } { | state } (render :: React.Render) -- spec :: React.ReactSpec props state React.ReactElement
+  -> { constructor :: React.ReactClassConstructor { children :: Children | props } { | state } (render :: React.Render, state :: { | state }) -- spec :: React.ReactSpec props state React.ReactElement
      , dispatcher :: React.ReactThis { children :: Children | props } { | state } -> action -> EventHandler
      }
 createReactSpec = createReactSpec' div'
@@ -219,15 +219,14 @@ createReactSpec'
   :: forall state props action
    . (Array React.ReactElement -> React.ReactElement)
   -> Spec { | state } { children :: Children | props } action
-  -> { | state }
-  -> { constructor :: React.ReactClassConstructor { children :: Children | props } { | state } (render :: React.Render) -- React.ReactSpec props state React.ReactElement
+  -> { | state } -- ^ Initial State
+  -> { constructor :: React.ReactClassConstructor { children :: Children | props } { | state } (render :: React.Render, state :: { | state }) -- React.ReactSpec props state React.ReactElement
      , dispatcher :: React.ReactThis { children :: Children | props } { | state } -> action -> EventHandler
      }
-createReactSpec' wrap (Spec spec) =
-    \state ->
-      { constructor: \this -> pure { render: render this } -- spec: React.spec state render
-      , dispatcher
-      }
+createReactSpec' wrap (Spec spec) initState =
+  { constructor: \this -> pure { render: render this, state: initState } -- spec: React.spec state render
+  , dispatcher
+  }
   where
     dispatcher :: React.ReactThis { children :: Children | props } { | state } -> action -> EventHandler
     dispatcher this action = void do

--- a/test/Components/Task.purs
+++ b/test/Components/Task.purs
@@ -15,7 +15,7 @@ data TaskAction
 -- | The state for the task component
 type Task =
   { completed :: Boolean
-    , description :: String
+  , description :: String
   }
 
 initialTask :: String -> Task
@@ -23,7 +23,7 @@ initialTask s = { completed: false, description: s }
 
 -- | A `Spec` for the task component.
 taskSpec :: forall props. T.Spec Task props TaskAction
-taskSpec = T.simpleSpec performAction render
+taskSpec = T.Spec {performAction,render}
   where
   -- Renders the current state of the component as a collection of React elements.
   render :: T.Render Task props TaskAction

--- a/test/Components/Task.purs
+++ b/test/Components/Task.purs
@@ -22,7 +22,7 @@ initialTask :: String -> Task
 initialTask s = { completed: false, description: s }
 
 -- | A `Spec` for the task component.
-taskSpec :: forall eff props. T.Spec eff Task props TaskAction
+taskSpec :: forall props. T.Spec Task props TaskAction
 taskSpec = T.simpleSpec performAction render
   where
   -- Renders the current state of the component as a collection of React elements.
@@ -34,7 +34,7 @@ taskSpec = T.simpleSpec performAction render
                   , RP.checked s.completed
                   , RP.title "Mark as completed"
                   , RP.onChange \e -> dispatch (ChangeCompleted (unsafeCoerce e).target.checked)
-                  ] []
+                  ]
         , R.text s.description
         , R.a [ RP.className "btn btn-danger pull-right"
               , RP.title "Remove item"
@@ -48,10 +48,10 @@ taskSpec = T.simpleSpec performAction render
   --
   -- _Note_: this component can only see actions of type `TaskAction`, but the `RemoveTask` action
   -- is ignored here: it will be handled by the parent component.
-  performAction :: T.PerformAction eff Task props TaskAction
+  performAction :: T.PerformAction Task props TaskAction
   performAction (ChangeCompleted b)   _ _ = void do
     -- This is a test for issue #65.
     -- In practice, we only need one `modifyState` here.
-    _ <- T.modifyState id
+    _ <- T.modifyState identity
     T.modifyState (_ { completed = b })
   performAction _                     _ _ = pure unit

--- a/test/Components/TaskList.purs
+++ b/test/Components/TaskList.purs
@@ -76,7 +76,7 @@ taskList = container $ fold
 
     -- The header component contains a button which will create a new task.
     header :: T.Spec TaskListState Props TaskListAction
-    header = T.simpleSpec performAction render
+    header = T.Spec {performAction,render}
       where
         render :: T.Render TaskListState Props TaskListAction
         render dispatch _ s _ =
@@ -152,16 +152,18 @@ taskList = container $ fold
     -- The footer uses `defaultPerformAction` since it neither produces nor handles actions.
     -- It simply displays a label with information about completed tasks.
     footer :: forall action. T.Spec TaskListState Props action
-    footer = T.simpleSpec T.defaultPerformAction \_ _ s _ ->
-      let
-        footerText = show completed <> "/" <> show total <> " tasks completed."
-        completed  = length $ filter _.completed s.tasks
-        total      = length s.tasks
-      in [ R.p' [ R.text footerText ] ]
+    footer = T.Spec {performAction: T.defaultPerformAction, render}
+      where
+        render _ _ s _ =
+          let
+            footerText = show completed <> "/" <> show total <> " tasks completed."
+            completed  = length $ filter _.completed s.tasks
+            total      = length s.tasks
+          in [ R.p' [ R.text footerText ] ]
 
     -- This `Spec` handles `RemoveTask` actions from child components
     listActions :: T.Spec TaskListState Props TaskListAction
-    listActions = T.simpleSpec performAction T.defaultRender
+    listActions = T.Spec {performAction, render: T.defaultRender}
       where
       performAction :: T.PerformAction TaskListState Props TaskListAction
       performAction (TaskAction i RemoveTask) _ _ = void $ T.modifyState \state -> state { tasks = fromMaybe state.tasks (deleteAt i state.tasks) }

--- a/test/Components/TaskList.purs
+++ b/test/Components/TaskList.purs
@@ -1,7 +1,6 @@
 module Components.TaskList where
 
 import Prelude
-import React.DOM.Props as RP
 import Thermite as T
 import Components.Task (Task, TaskAction(..), taskSpec, initialTask)
 import Data.Either (Either(..))
@@ -13,6 +12,9 @@ import Data.Maybe (fromMaybe)
 import Data.Tuple (Tuple(..), uncurry)
 import React (ReactElement) as R
 import React.DOM (text, p', td', input, tr', tbody', th, thead', table, div, h1', button) as R
+import React.DOM.Props as RP
+import React.SyntheticEvent (SyntheticKeyboardEvent, SyntheticUIEvent, target, keyCode) as R
+import Effect (Effect)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | An action for the full task list component
@@ -21,6 +23,9 @@ data TaskListAction
   | SetEditText String
   | SetFilter Filter
   | TaskAction Int TaskAction
+
+-- | Nullary props
+type Props = T.WithChildren ()
 
 -- | A `Prism` which corresponds to the `TaskAction` constructor.
 _TaskAction :: Prism' TaskListAction (Tuple Int TaskAction)
@@ -53,7 +58,7 @@ _tasks = lens _.tasks (_ { tasks = _ })
 -- | Lens and monoid combinators are used to compose them.
 -- |
 -- | Take note of the different state and action types for each component.
-taskList :: forall props eff. T.Spec eff TaskListState props TaskListAction
+taskList :: T.Spec TaskListState Props TaskListAction
 taskList = container $ fold
     [ header
     , table $ T.withState \st ->
@@ -64,15 +69,15 @@ taskList = container $ fold
     ]
   where
     -- | A function which wraps a `Spec`'s `Render` function with a `container` element.
-    container :: forall state action. T.Spec eff state props action -> T.Spec eff state props action
+    container :: forall state action. T.Spec state Props action -> T.Spec state Props action
     container = over T._render \render d p s c ->
       [ R.div [ RP.className "container" ] (render d p s c) ]
 
     -- The header component contains a button which will create a new task.
-    header :: T.Spec eff TaskListState props TaskListAction
+    header :: T.Spec TaskListState Props TaskListAction
     header = T.simpleSpec performAction render
       where
-        render :: T.Render TaskListState props TaskListAction
+        render :: T.Render TaskListState Props TaskListAction
         render dispatch _ s _ =
           [ R.h1' [ R.text "todo list" ]
           , R.div [ RP.className "btn-group" ] (map filter_ [ All, Active, Completed ])
@@ -86,7 +91,7 @@ taskList = container $ fold
 
         -- The `NewTask` action is handled here
         -- Everything else is handled by some other child component so is ignored here.
-        performAction :: T.PerformAction eff TaskListState props TaskListAction
+        performAction :: T.PerformAction TaskListState Props TaskListAction
         performAction (NewTask s) _ _ = void $ T.modifyState $ \state ->
           state { tasks = Cons (initialTask s) state.tasks
                 , editText = ""
@@ -94,7 +99,7 @@ taskList = container $ fold
         performAction _ _ _ = pure unit
 
     -- This function wraps a `Spec`'s `Render` function to filter out tasks.
-    applyFilter :: forall action. Filter -> T.Spec eff Task props action -> T.Spec eff Task props action
+    applyFilter :: forall action. Filter -> T.Spec Task Props action -> T.Spec Task Props action
     applyFilter filter = over T._render \render d p s c ->
       if matches filter s
         then render d p s c
@@ -105,12 +110,24 @@ taskList = container $ fold
       matches Active    t = not t.completed
 
     -- This function wraps a `Spec`'s `Render` function in a table with the correct row headers.
-    table :: T.Spec eff TaskListState props TaskListAction -> T.Spec eff TaskListState props TaskListAction
+    table :: T.Spec TaskListState Props TaskListAction -> T.Spec TaskListState Props TaskListAction
     table = over T._render \render dispatch p s c ->
-      let handleKeyPress :: Int -> String -> T.EventHandler
-          handleKeyPress 13 text = dispatch $ NewTask text
-          handleKeyPress 27 _    = dispatch $ SetEditText ""
-          handleKeyPress _  _    = pure unit
+      let handleKeyPress :: R.SyntheticKeyboardEvent -> Effect Unit
+          handleKeyPress e = do
+            k <- R.keyCode e
+            case unit of
+              _ | k == 27.0 -> dispatch (SetEditText "")
+                | k == 13.0 -> do
+                  t <- R.target e
+                  dispatch (NewTask (unsafeCoerce t).value)
+                | otherwise -> pure unit
+          setValue :: R.SyntheticUIEvent -> Effect Unit
+          setValue e = do
+            t <- R.target e
+            dispatch (SetEditText (unsafeCoerce t).value)
+          -- handleKeyPress 13 text = dispatch $ NewTask text
+          -- handleKeyPress 27 _    = dispatch $ SetEditText ""
+          -- handleKeyPress _  _    = pure unit
       in [ R.table [ RP.className "table table-striped" ]
                    [ R.thead' $ [ R.tr' [ R.th [ RP.className "col-md-1"  ] []
                                         , R.th [ RP.className "col-md-10" ] [ R.text "Description" ]
@@ -121,9 +138,9 @@ taskList = container $ fold
                                         , R.td' [ R.input [ RP.className "form-control"
                                                           , RP.placeholder "Create a new task"
                                                           , RP.value s.editText
-                                                          , RP.onKeyUp \e -> handleKeyPress (unsafeCoerce e).keyCode (unsafeCoerce e).target.value
-                                                          , RP.onChange \e -> dispatch (SetEditText (unsafeCoerce e).target.value)
-                                                          ] []
+                                                          , RP.onKeyUp handleKeyPress
+                                                          , RP.onChange setValue
+                                                          ]
                                                 ]
                                         , R.td' []
                                         ]
@@ -133,7 +150,7 @@ taskList = container $ fold
 
     -- The footer uses `defaultPerformAction` since it neither produces nor handles actions.
     -- It simply displays a label with information about completed tasks.
-    footer :: forall action. T.Spec eff TaskListState props action
+    footer :: forall action. T.Spec TaskListState Props action
     footer = T.simpleSpec T.defaultPerformAction \_ _ s _ ->
       let
         footerText = show completed <> "/" <> show total <> " tasks completed."
@@ -142,10 +159,10 @@ taskList = container $ fold
       in [ R.p' [ R.text footerText ] ]
 
     -- This `Spec` handles `RemoveTask` actions from child components
-    listActions :: T.Spec eff TaskListState props TaskListAction
+    listActions :: T.Spec TaskListState Props TaskListAction
     listActions = T.simpleSpec performAction T.defaultRender
       where
-      performAction :: T.PerformAction eff TaskListState props TaskListAction
+      performAction :: T.PerformAction TaskListState Props TaskListAction
       performAction (TaskAction i RemoveTask) _ _ = void $ T.modifyState \state -> state { tasks = fromMaybe state.tasks (deleteAt i state.tasks) }
       performAction (SetEditText s)           _ _ = void $ T.modifyState (_ { editText = s })
       performAction (SetFilter f)             _ _ = void $ T.modifyState (_ { filter = f })

--- a/test/Components/TaskList.purs
+++ b/test/Components/TaskList.purs
@@ -7,7 +7,8 @@ import Data.Either (Either(..))
 import Data.Filter (Filter(..), showFilter)
 import Data.Foldable (fold)
 import Data.Lens (Lens', Prism', over, lens, prism)
-import Data.List (List(..), deleteAt, length, filter)
+import Data.Array (cons, deleteAt, length, filter)
+-- import Data.List (List(..), deleteAt, length, filter)
 import Data.Maybe (fromMaybe)
 import Data.Tuple (Tuple(..), uncurry)
 import React (ReactElement) as R
@@ -36,20 +37,20 @@ _TaskAction = prism (uncurry TaskAction) \ta ->
 
 -- | The state for the full task list component is a list of tasks
 type TaskListState =
-  { tasks       :: List Task
+  { tasks       :: Array Task
   , editText    :: String
   , filter      :: Filter
   }
 
 initialTaskListState :: TaskListState
 initialTaskListState =
-  { tasks: Nil
+  { tasks: []
   , editText: ""
   , filter: All
   }
 
 -- | A `Lens` which corresponds to the `tasks` property.
-_tasks :: Lens' TaskListState (List Task)
+_tasks :: Lens' TaskListState (Array Task)
 _tasks = lens _.tasks (_ { tasks = _ })
 
 -- | A `Spec` for a component consisting of a `List` of tasks.
@@ -93,7 +94,7 @@ taskList = container $ fold
         -- Everything else is handled by some other child component so is ignored here.
         performAction :: T.PerformAction TaskListState Props TaskListAction
         performAction (NewTask s) _ _ = void $ T.modifyState $ \state ->
-          state { tasks = Cons (initialTask s) state.tasks
+          state { tasks = cons (initialTask s) state.tasks
                 , editText = ""
                 }
         performAction _ _ _ = pure unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -15,10 +15,9 @@ module Test.Main (main) where
 
 import Prelude
 import Components.TaskList (initialTaskListState, taskList)
-import Control.Monad.Eff (Eff)
-import DOM (DOM) as DOM
+import Effect (Effect)
 import Thermite as T
 
 -- | The main method creates the task list component, and renders it to the document body.
-main :: Eff (dom :: DOM.DOM) Unit
-main = T.defaultMain taskList initialTaskListState unit
+main :: Effect Unit
+main = T.defaultMain taskList initialTaskListState "TaskList" {}


### PR DESCRIPTION
Hi there,

I took the liberty of upgrading most of what needs to be upgraded for the new React v16 and psc v0.12; so far my tests seem to prove successful - here's an example project that relies on this commit as a dependency: https://github.com/athanclark/purescript-material-ui/tree/master/example

# Actions taken

- the `EventHandler` type alias was changed to `Dispatcher :: Type -> Type`, indexed by the `action` type, because the `ReactProps`, `ReactState` etc. effect kinds no longer exist.
- `createReactSpec` was turned into `createReactConstructor`, to reflect React v16's new "class constructor" paradigm.
- the `eff :: # Type` variable no longer exists in `Spec` or `PerformAction`
- `simpleSpec` no longer exists - it's just an alias for the newtype constructor
- `WithChildren` type alias created, for simpler `{ children :: Children | props }` referencing

That's about it! Other edits are just cosmetic, and account for the inline documentation changes, except for one specific line: https://github.com/athanclark/purescript-thermite/blob/b46ecf35b56b779af00fdb471a4c9ed1c4d1b330/src/Thermite.purs#L257

Here, in `defaultMain`, I'm creating the React element from the `ReactClassConstructor` using the empty array `[]` as the "children" argument - this decision was made to keep a similar type signature for `defaultMain`, and because `React.createElement` and `React.unsafeCreateElement` allow access to the `this.children` property only _within_ the React component - external access (i.e., within `defaultMain` and __not__ `render`) to `this.children` is forbidden.